### PR TITLE
fixed deposit/withdraw/stake/unstake tests in test_StakeUtils.ts

### DIFF
--- a/packages/pool/test/test_StakeUtils.ts
+++ b/packages/pool/test/test_StakeUtils.ts
@@ -328,7 +328,6 @@ describe('StakeUtils_singleTransactionActions_and_reverts', () => {
     await token.connect(signer).approve(pool.address, testValue);
     await staker.depositAndStake(accounts[1], testValue, accounts[1]);
     // get starting values
-    const startUserShares = await pool.shares(accounts[1]);
     const startUserBalance = await token.balanceOf(accounts[1]);
     const startUnstaked = (await pool.users(accounts[1])).unstaked;
     const startStaked = await pool.userStaked(accounts[1]);
@@ -345,6 +344,8 @@ describe('StakeUtils_singleTransactionActions_and_reverts', () => {
     const totalStakeAtUnstake = await pool.totalStake();
     const totalSharesAtUnstake = await pool.totalSupply();
     const sharesToBurn = totalSharesAtUnstake.mul(startStaked).div(totalStakeAtUnstake);
+    const userSharesAtUnstake = await pool.shares(accounts[1]);
+    const expectedEndShares = userSharesAtUnstake.sub(sharesToBurn);
     // unstake and withdraw tokens
     await staker.unstakeAndWithdraw(accounts[1]);
     // // calculate expected remaining stake
@@ -353,11 +354,13 @@ describe('StakeUtils_singleTransactionActions_and_reverts', () => {
     const endUserBalance = await token.balanceOf(accounts[1]);
     const endUnstaked = (await pool.users(accounts[1])).unstaked;
     const endStaked = await pool.userStaked(accounts[1]);
+    const endTotalShares = await pool.totalSupply();
     // check result
     expect(endUserBalance).to.equal(startUserBalance.add(startStaked));
-    expect(endUserShares).to.equal(startUserShares.sub(sharesToBurn));
+    expect(endUserShares).to.equal(expectedEndShares);
     expect(endUnstaked).to.equal(startUnstaked);
     expect(endStaked).to.equal(0);
+    expect(endTotalShares).to.equal(totalSharesAtUnstake.sub(sharesToBurn));
   })
 
 })

--- a/packages/pool/typechain/TestPool.d.ts
+++ b/packages/pool/typechain/TestPool.d.ts
@@ -35,6 +35,7 @@ interface TestPoolInterface extends ethers.utils.Interface {
     "genesisEpoch()": FunctionFragment;
     "getCurrentEpoch()": FunctionFragment;
     "getOldestLockedEpochTest()": FunctionFragment;
+    "getRevokedEpochReward(address,uint256)": FunctionFragment;
     "getRewardTargetEpochTest()": FunctionFragment;
     "getUserLocked(address)": FunctionFragment;
     "getUserLockedAt(address,uint256)": FunctionFragment;
@@ -126,6 +127,10 @@ interface TestPoolInterface extends ethers.utils.Interface {
   encodeFunctionData(
     functionFragment: "getOldestLockedEpochTest",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "getRevokedEpochReward",
+    values: [string, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "getRewardTargetEpochTest",
@@ -324,6 +329,10 @@ interface TestPoolInterface extends ethers.utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "getOldestLockedEpochTest",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "getRevokedEpochReward",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -632,6 +641,18 @@ export class TestPool extends Contract {
     "getOldestLockedEpochTest()"(
       overrides?: CallOverrides
     ): Promise<[BigNumber]>;
+
+    getRevokedEpochReward(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<[boolean]>;
+
+    "getRevokedEpochReward(address,uint256)"(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<[boolean]>;
 
     getRewardTargetEpochTest(overrides?: CallOverrides): Promise<[BigNumber]>;
 
@@ -1201,6 +1222,18 @@ export class TestPool extends Contract {
 
   "getOldestLockedEpochTest()"(overrides?: CallOverrides): Promise<BigNumber>;
 
+  getRevokedEpochReward(
+    userAddress: string,
+    targetEpoch: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<boolean>;
+
+  "getRevokedEpochReward(address,uint256)"(
+    userAddress: string,
+    targetEpoch: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<boolean>;
+
   getRewardTargetEpochTest(overrides?: CallOverrides): Promise<BigNumber>;
 
   "getRewardTargetEpochTest()"(overrides?: CallOverrides): Promise<BigNumber>;
@@ -1761,6 +1794,18 @@ export class TestPool extends Contract {
     getOldestLockedEpochTest(overrides?: CallOverrides): Promise<BigNumber>;
 
     "getOldestLockedEpochTest()"(overrides?: CallOverrides): Promise<BigNumber>;
+
+    getRevokedEpochReward(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<boolean>;
+
+    "getRevokedEpochReward(address,uint256)"(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<boolean>;
 
     getRewardTargetEpochTest(overrides?: CallOverrides): Promise<BigNumber>;
 
@@ -2369,6 +2414,18 @@ export class TestPool extends Contract {
 
     "getOldestLockedEpochTest()"(overrides?: CallOverrides): Promise<BigNumber>;
 
+    getRevokedEpochReward(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    "getRevokedEpochReward(address,uint256)"(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     getRewardTargetEpochTest(overrides?: CallOverrides): Promise<BigNumber>;
 
     "getRewardTargetEpochTest()"(overrides?: CallOverrides): Promise<BigNumber>;
@@ -2856,6 +2913,18 @@ export class TestPool extends Contract {
     ): Promise<PopulatedTransaction>;
 
     "getOldestLockedEpochTest()"(
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    getRevokedEpochReward(
+      userAddress: string,
+      targetEpoch: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    "getRevokedEpochReward(address,uint256)"(
+      userAddress: string,
+      targetEpoch: BigNumberish,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 


### PR DESCRIPTION
One test is failing in an unimportant respect. When attempting to unstake and withdraw all tokens in one transaction, some staked tokens remain. The requested unstake amount is correctly unstaked, but rewards are only revoked for the epoch in which the unstake request is made yet rewards are granted for the epoch in which the unstake actually occurs. This isn't necessarily a bug.