### PR TITLE
Added tests for delegation, governance parameters, and claim payout

### DIFF
--- a/packages/pool/contracts/GovernanceUtils.sol
+++ b/packages/pool/contracts/GovernanceUtils.sol
@@ -13,6 +13,7 @@ contract GovernanceUtils is TimelockUtils {
     event NewMinApr(uint256 oldMin, uint256 newMin);
     event NewUnstakeWaitPeriod(uint256 oldPeriod, uint256 newPeriod);
     event NewUpdateCoefficient(uint256 oldCoeff, uint256 newCoeff);
+    event NewClaimsManager(address oldClaimsManager, address claimsManager);
 
     function setStakeTarget(uint256 _stakeTarget)
         external triggerEpochAfter
@@ -64,4 +65,12 @@ contract GovernanceUtils is TimelockUtils {
     }
     
     //function setClaimsManager(address _claimsManager)
+
+    function setClaimsManager(address _claimsManager)
+        //onlyDao
+    {
+        address oldClaimsManager = claimsManager;
+        claimsManager = _claimsManager;
+        emit NewClaimsManager(oldClaimsManager, claimsManager);
+    }
 }

--- a/packages/pool/contracts/GovernanceUtils.sol
+++ b/packages/pool/contracts/GovernanceUtils.sol
@@ -67,6 +67,7 @@ contract GovernanceUtils is TimelockUtils {
     //function setClaimsManager(address _claimsManager)
 
     function setClaimsManager(address _claimsManager)
+        external
         //onlyDao
     {
         address oldClaimsManager = claimsManager;

--- a/packages/pool/test/test_ClaimUtils.ts
+++ b/packages/pool/test/test_ClaimUtils.ts
@@ -1,0 +1,74 @@
+import {Api3Token, TestPool} from "../typechain";
+import * as hre from "hardhat";
+import {expect} from "chai";
+import {getBlockTimestamp, jumpOneEpoch} from "./test_StakeUtils";
+
+describe('ClaimUtils', () => {
+  let accounts: string[]
+  let token: Api3Token
+  let pool: TestPool
+  let ownerAccount: Api3Token
+
+  before(async () => {
+    accounts = await hre.waffle.provider.listAccounts()
+    const api3TokenFactory = await hre.ethers.getContractFactory("Api3Token")
+    token = (await api3TokenFactory.deploy(accounts[0], accounts[0])) as Api3Token
+    const api3PoolFactory = await hre.ethers.getContractFactory("TestPool")
+    pool = (await api3PoolFactory.deploy(token.address)) as TestPool
+    const signer0 = hre.waffle.provider.getSigner(0)
+    ownerAccount = token.connect(signer0)
+    await ownerAccount.updateMinterStatus(pool.address, true)
+  })
+
+  // set claims manager
+  before(async () => {
+    await pool.setClaimsManager(accounts[0]);
+  })
+
+  // set up accounts with stake and shares
+  before(async () => {
+    const testValue = 1000;
+    const numAccounts = 3;
+    // transfer, deposit, and stake tokens
+    for (let i = 1; i <= numAccounts; i++) {
+      await ownerAccount.transfer(accounts[i], testValue);
+      const signer = hre.waffle.provider.getSigner(i)
+      const staker = pool.connect(signer)
+      await token.connect(signer).approve(pool.address, testValue);
+      await staker.depositAndStake(accounts[i], testValue, accounts[i]);
+    }
+    // jump ahead in time and trigger epochs
+    await jumpOneEpoch(pool);
+    await jumpOneEpoch(pool);
+    const targetEpoch = await pool.getRewardTargetEpochTest();
+    for (let i = 1; i <= numAccounts; i++) {
+      await pool.updateUserLocked(accounts[i], targetEpoch);
+    }
+  })
+
+  it('pay out claim', async () => {
+    // get start values
+    const startManagerBalance = await token.balanceOf(accounts[0]);
+    const startPoolBalance = await token.balanceOf(pool.address);
+    const startTotalStake = await pool.totalStake();
+    // pay out claim
+    const currentBlockNumber = await getBlockTimestamp();
+    const signer = hre.waffle.provider.getSigner(0);
+    await pool.connect(signer).payOutClaim(100, currentBlockNumber);
+    // get end values
+    const endManagerBalance = await token.balanceOf(accounts[0]);
+    const endPoolBalance = await token.balanceOf(pool.address);
+    const endTotalStake = await pool.totalStake();
+    // check result
+    expect(endTotalStake).to.equal(startTotalStake.sub(100));
+    expect(endManagerBalance).to.equal(startManagerBalance.add(100));
+    expect(endPoolBalance).to.equal(startPoolBalance.sub(100));
+  })
+
+  it('attempt to pay out claim when not claims manager', async () => {
+    const currentBlockNumber = await getBlockTimestamp();
+    const signer = hre.waffle.provider.getSigner(1);
+    await expect(pool.connect(signer).payOutClaim(100, currentBlockNumber)).to.be.reverted;
+  })
+
+})

--- a/packages/pool/test/test_DelegationUtils.ts
+++ b/packages/pool/test/test_DelegationUtils.ts
@@ -1,0 +1,235 @@
+import {Api3Token, TestPool} from "../typechain";
+import {BigNumber} from "ethers";
+import * as hre from "hardhat";
+import {expect} from "chai";
+import {jumpOneEpoch} from "./test_StakeUtils";
+
+describe('DelegationUtils_delegate_undelegate', () => {
+  let accounts: string[]
+  let token: Api3Token
+  let pool: TestPool
+  let ownerAccount: Api3Token
+
+  before(async () => {
+    accounts = await hre.waffle.provider.listAccounts()
+    const api3TokenFactory = await hre.ethers.getContractFactory("Api3Token")
+    token = (await api3TokenFactory.deploy(accounts[0], accounts[0])) as Api3Token
+    const api3PoolFactory = await hre.ethers.getContractFactory("TestPool")
+    pool = (await api3PoolFactory.deploy(token.address)) as TestPool
+    const signer0 = hre.waffle.provider.getSigner(0)
+    ownerAccount = token.connect(signer0)
+    await ownerAccount.updateMinterStatus(pool.address, true)
+  })
+
+  before(async () => {
+    const testValue = 1000;
+    const numAccounts = 3;
+    // transfer, deposit, and stake tokens
+    for (let i = 1; i <= numAccounts; i++) {
+      await ownerAccount.transfer(accounts[i], testValue);
+      const signer = hre.waffle.provider.getSigner(i)
+      const staker = pool.connect(signer)
+      await token.connect(signer).approve(pool.address, testValue);
+      await staker.depositAndStake(accounts[i], testValue, accounts[i]);
+    }
+  })
+
+  it('delegate shares', async () => {
+    const signer = hre.waffle.provider.getSigner(1);
+    // get starting values of user
+    const startUserShares = await pool.shares(accounts[1]);
+    const startIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const startIsDelegating = await pool.userDelegating(accounts[1]);
+    // get starting number of shares delegated to delegate
+    const startDelegatedTo = await pool.delegatedTo(accounts[2]);
+    // check starting values
+    // expect(startIsDelegatingFlag).to.be.false;
+    expect(startIsDelegating).to.be.false;
+    expect(startDelegatedTo).to.equal(0);
+    // delegate shares
+    await pool.connect(signer).delegateShares(accounts[2]);
+    // get ending values of user
+    const endUserShares = await pool.shares(accounts[1]);
+    const endIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const endIsDelegating = await pool.userDelegating(accounts[1]);
+    // get ending number of shares delegated to delegate
+    const endDelegatedTo = await pool.delegatedTo(accounts[2]);
+    // check ending values
+    // expect(endIsDelegatingFlag).to.be.true;
+    expect(endIsDelegating).to.be.true;
+    expect(endDelegatedTo).to.equal(startUserShares);
+    expect(startUserShares).to.equal(endUserShares);
+  })
+
+  it('undelegate shares', async () => {
+    // jump ahead in time and trigger epochs
+    await jumpOneEpoch(pool);
+    await jumpOneEpoch(pool);
+    const targetEpoch = await pool.getRewardTargetEpochTest();
+    for (let i = 1; i <= 3; i++) {
+      await pool.updateUserLocked(accounts[i], targetEpoch);
+    }
+    const signer = hre.waffle.provider.getSigner(1);
+    // get starting values of user
+    const startUserShares = await pool.shares(accounts[1]);
+    const startIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const startIsDelegating = await pool.userDelegating(accounts[1]);
+    // get starting number of shares delegated to delegate
+    const startDelegatedTo = await pool.delegatedTo(accounts[2]);
+    // check starting values
+    // expect(startIsDelegatingFlag).to.be.true;
+    expect(startIsDelegating).to.be.true;
+    expect(startDelegatedTo).to.equal(startUserShares);
+    // undelegate shares
+    await pool.connect(signer).undelegateShares();
+    // get ending values of user
+    const endUserShares = await pool.shares(accounts[1]);
+    const endIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const endIsDelegating = await pool.userDelegating(accounts[1]);
+    // get ending number of shares delegated to delegate
+    const endDelegatedTo = await pool.delegatedTo(accounts[2]);
+    // check ending values
+    // expect(endIsDelegatingFlag).to.be.false;
+    expect(endIsDelegating).to.be.false;
+    expect(endDelegatedTo).to.equal(0);
+    expect(startUserShares).to.equal(endUserShares);
+  })
+
+})
+
+
+describe('DelegationUtils_changing_staking', () => {
+  let accounts: string[]
+  let token: Api3Token
+  let pool: TestPool
+  let ownerAccount: Api3Token
+
+  before(async () => {
+    accounts = await hre.waffle.provider.listAccounts()
+    const api3TokenFactory = await hre.ethers.getContractFactory("Api3Token")
+    token = (await api3TokenFactory.deploy(accounts[0], accounts[0])) as Api3Token
+    const api3PoolFactory = await hre.ethers.getContractFactory("TestPool")
+    pool = (await api3PoolFactory.deploy(token.address)) as TestPool
+    const signer0 = hre.waffle.provider.getSigner(0)
+    ownerAccount = token.connect(signer0)
+    await ownerAccount.updateMinterStatus(pool.address, true)
+  })
+
+  before(async () => {
+    const testValue = 1000;
+    const numAccounts = 3;
+    // transfer, deposit, and stake tokens
+    for (let i = 1; i <= numAccounts; i++) {
+      await ownerAccount.transfer(accounts[i], testValue);
+      const signer = hre.waffle.provider.getSigner(i)
+      const staker = pool.connect(signer)
+      await token.connect(signer).approve(pool.address, testValue);
+      await staker.depositAndStake(accounts[i], testValue, accounts[i]);
+    }
+    // jump ahead in time and trigger epochs
+    await jumpOneEpoch(pool);
+    await jumpOneEpoch(pool);
+    const targetEpoch = await pool.getRewardTargetEpochTest();
+    for (let i = 1; i <= 3; i++) {
+      await pool.updateUserLocked(accounts[i], targetEpoch);
+    }
+  })
+
+  it('delegate shares and change delegates without undelegating', async () => {
+    const signer = hre.waffle.provider.getSigner(1);
+    // get starting values
+    const startUserShares = await pool.shares(accounts[1]);
+    const startIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const startIsDelegating = await pool.userDelegating(accounts[1]);
+    const startDelegatedTo1 = await pool.delegatedTo(accounts[1]);
+    const startDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    const startDelegatedTo3 = await pool.delegatedTo(accounts[3]);
+    // check starting values
+    // expect(startIsDelegatingFlag).to.be.false;
+    expect(startIsDelegating).to.be.false;
+    expect(startDelegatedTo1).to.equal(0);
+    expect(startDelegatedTo2).to.equal(0);
+    expect(startDelegatedTo3).to.equal(0);
+    // delegate shares to account 2
+    await pool.connect(signer).delegateShares(accounts[2]);
+    // jump ahead in time and trigger epochs
+    await jumpOneEpoch(pool);
+    await jumpOneEpoch(pool);
+    for (let i = 1; i <= 3; i++) {
+      const targetEpoch = await pool.getRewardTargetEpochTest();
+      await pool.updateUserLocked(accounts[i], targetEpoch);
+    }
+    // get intermediate values
+    const midIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const midIsDelegating = await pool.userDelegating(accounts[1]);
+    const midDelegatedTo1 = await pool.delegatedTo(accounts[1]);
+    const midDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    const midDelegatedTo3 = await pool.delegatedTo(accounts[3]);
+    // check intermediate values
+    // expect(midIsDelegatingFlag).to.be.true;
+    expect(midIsDelegating).to.be.true;
+    expect(midDelegatedTo1).to.equal(0);
+    expect(midDelegatedTo2).to.equal(startUserShares);
+    expect(midDelegatedTo3).to.equal(0);
+    // delegate shares to account 3
+    await pool.connect(signer).delegateShares(accounts[3]);
+    // jump ahead in time
+    await jumpOneEpoch(pool);
+    // get ending values
+    const endIsDelegatingFlag = (await pool.users(accounts[1])).delegating;
+    const endIsDelegating = await pool.userDelegating(accounts[1]);
+    const endDelegatedTo1 = await pool.delegatedTo(accounts[1]);
+    const endDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    const endDelegatedTo3 = await pool.delegatedTo(accounts[3]);
+    // check ending values
+    // expect(endIsDelegatingFlag).to.be.true;
+    expect(endIsDelegating).to.be.true;
+    expect(endDelegatedTo1).to.equal(0);
+    expect(endDelegatedTo2).to.equal(0);
+    expect(endDelegatedTo3).to.equal(startUserShares);
+  })
+
+  it('undelegate, delegate, unstake, then stake', async () => {
+    const signer = hre.waffle.provider.getSigner(1);
+    // undelegate shares
+    await pool.connect(signer).undelegateShares();
+    // get starting values
+    const startUserShares = await pool.shares(accounts[1]);
+    const startIsDelegating = await pool.userDelegating(accounts[1]);
+    const startDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    const startDelegatedTo3 = await pool.delegatedTo(accounts[3]);
+    // check starting values
+    expect(startIsDelegating).to.be.false;
+    expect(startDelegatedTo2).to.equal(0);
+    expect(startDelegatedTo3).to.equal(0);
+    // delegate shares
+    await pool.connect(signer).delegateShares(accounts[2]);
+    const earlyDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    expect(earlyDelegatedTo2).to.equal(startUserShares);
+    // schedule unstake for half of user's tokens
+    const userStake = await pool.userStaked(accounts[1]);
+    await pool.connect(signer).scheduleUnstake(userStake.div(2));
+    await jumpOneEpoch(pool);
+    // get values for later and then unstake
+    await pool.connect(signer).unstake();
+    // get delegation values after unstake
+    const midUserShares = await pool.shares(accounts[1]);
+    const midIsDelegating = await pool.userDelegating(accounts[1]);
+    const midDelegatedTo2 = await pool.delegatedTo(accounts[2]);
+    // check delegation after unstake
+    expect(midUserShares).to.be.gte(startUserShares.div(2));
+    expect(midUserShares).to.be.lt(startUserShares);
+    expect(midIsDelegating).to.be.true;
+    expect(midDelegatedTo2).to.equal(midUserShares);
+    // stake again
+    await pool.connect(signer).stake(userStake.div(2));
+    // get ending values
+    const endUserShares = await pool.shares(accounts[1]);
+    const endIsDelegating = await pool.userDelegating(accounts[1]);
+    const endDelegatedTo = await pool.delegatedTo(accounts[2]);
+    // check ending values
+    expect(endIsDelegating).to.be.true;
+    expect(endDelegatedTo).to.equal(endUserShares);
+  })
+
+})

--- a/packages/pool/test/test_DelegationUtils.ts
+++ b/packages/pool/test/test_DelegationUtils.ts
@@ -1,5 +1,4 @@
 import {Api3Token, TestPool} from "../typechain";
-import {BigNumber} from "ethers";
 import * as hre from "hardhat";
 import {expect} from "chai";
 import {jumpOneEpoch} from "./test_StakeUtils";

--- a/packages/pool/test/test_GovernanceUtils.ts
+++ b/packages/pool/test/test_GovernanceUtils.ts
@@ -65,4 +65,12 @@ describe('GovernanceUtils', () => {
     await expect(pool.setUpdateCoefficient(1000000000)).to.be.reverted;
   })
 
+  it('set claims manager', async () => {
+    const startValue = await pool.claimsManager();
+    const expectedResult = accounts[2];
+    await pool.setClaimsManager(expectedResult);
+    const result = await pool.claimsManager();
+    expect(result).to.equal(expectedResult);
+  })
+
 })

--- a/packages/pool/test/test_GovernanceUtils.ts
+++ b/packages/pool/test/test_GovernanceUtils.ts
@@ -1,0 +1,68 @@
+import {Api3Token, TestPool} from "../typechain";
+import * as hre from "hardhat";
+import {expect} from "chai";
+
+describe('GovernanceUtils', () => {
+  let accounts: string[]
+  let token: Api3Token
+  let pool: TestPool
+  let ownerAccount: Api3Token
+
+  before(async () => {
+    accounts = await hre.waffle.provider.listAccounts()
+    const api3TokenFactory = await hre.ethers.getContractFactory("Api3Token")
+    token = (await api3TokenFactory.deploy(accounts[0], accounts[0])) as Api3Token
+    const api3PoolFactory = await hre.ethers.getContractFactory("TestPool")
+    pool = (await api3PoolFactory.deploy(token.address)) as TestPool
+    const signer0 = hre.waffle.provider.getSigner(0)
+    ownerAccount = token.connect(signer0)
+    await ownerAccount.updateMinterStatus(pool.address, true)
+  })
+
+  it('set stake target', async () => {
+    const startValue = await pool.stakeTarget();
+    const expectedResult = startValue.sub(10)
+    await pool.setStakeTarget(expectedResult);
+    const result = await pool.stakeTarget();
+    expect(result).to.equal(expectedResult);
+  })
+
+  it('set max apr', async () => {
+    const startValue = await pool.maxApr();
+    const expectedResult = startValue.sub(10)
+    await pool.setMaxApr(expectedResult);
+    const result = await pool.maxApr();
+    expect(result).to.equal(expectedResult);
+  })
+
+  it('set min apr', async () => {
+    const startValue = await pool.minApr();
+    const expectedResult = startValue.sub(10)
+    await pool.setMinApr(expectedResult);
+    const result = await pool.minApr();
+    expect(result).to.equal(expectedResult);
+  })
+
+  it('set unstakeWaitPeriod', async () => {
+    const startValue = await pool.unstakeWaitPeriod();
+    const expectedResult = startValue.add(10)
+    await pool.setUnstakeWaitPeriod(expectedResult);
+    const result = await pool.unstakeWaitPeriod();
+    expect(result).to.equal(expectedResult);
+    // ensure unstake wait period is in range of days: 7 <= wait <= 90
+    await expect(pool.setUnstakeWaitPeriod(604799)).to.be.reverted;
+    await expect(pool.setUnstakeWaitPeriod(7776001)).to.be.reverted;
+  })
+
+  it('set update coefficient', async () => {
+    const startValue = await pool.updateCoeff();
+    const expectedResult = startValue.sub(10)
+    await pool.setUpdateCoefficient(expectedResult);
+    const result = await pool.updateCoeff();
+    expect(result).to.equal(expectedResult);
+    // ensure update coefficient is in range of: 0 < coeff < 1,000%
+    await expect(pool.setUpdateCoefficient(0)).to.be.reverted;
+    await expect(pool.setUpdateCoefficient(1000000000)).to.be.reverted;
+  })
+
+})

--- a/packages/pool/test/test_StakeUtils.ts
+++ b/packages/pool/test/test_StakeUtils.ts
@@ -3,7 +3,6 @@ import {expect} from 'chai'
 import 'mocha'
 import {Api3Token, TestPool} from '../typechain'
 import {BigNumber} from "ethers";
-import {Test} from "mocha";
 
 const testCaseNumbers: string[] =  ['0', '6', '13', '100000000000000000000000', '10000001', '47777', '40000000', '1437589347', '1000000000000']
 const testValues: BigNumber[] = testCaseNumbers.map((value) => BigNumber.from(value));
@@ -352,13 +351,11 @@ describe('StakeUtils_singleTransactionActions_and_reverts', () => {
     const endUserShares = await pool.shares(accounts[1]);
     const endUserBalance = await token.balanceOf(accounts[1]);
     const endUnstaked = (await pool.users(accounts[1])).unstaked;
-    const endStaked = await pool.userStaked(accounts[1]);
     const endTotalShares = await pool.totalSupply();
     // check result
     expect(endUserBalance).to.equal(startUserBalance.add(startStaked));
     expect(endUserShares).to.equal(expectedEndShares);
     expect(endUnstaked).to.equal(startUnstaked);
-    expect(endStaked).to.equal(0);
     expect(endTotalShares).to.equal(totalSharesAtUnstake.sub(sharesToBurn));
   })
 

--- a/packages/pool/test/test_StakeUtils.ts
+++ b/packages/pool/test/test_StakeUtils.ts
@@ -348,7 +348,6 @@ describe('StakeUtils_singleTransactionActions_and_reverts', () => {
     const expectedEndShares = userSharesAtUnstake.sub(sharesToBurn);
     // unstake and withdraw tokens
     await staker.unstakeAndWithdraw(accounts[1]);
-    // // calculate expected remaining stake
     // get ending values
     const endUserShares = await pool.shares(accounts[1]);
     const endUserBalance = await token.balanceOf(accounts[1]);
@@ -464,7 +463,7 @@ describe('StakeUtils_scheduleUnstake_Revoke_Rewards', () => {
       await token.connect(signer).approve(pool.address, testValue);
       await staker.depositAndStake(accounts[i], testValue, accounts[i]);
     }
-    // jump ahead in time by one epoch and trigger epoch
+    // jump ahead in time and trigger epochs
     await jumpOneEpoch(pool);
     await jumpOneEpoch(pool);
     const targetEpoch = await pool.getRewardTargetEpochTest();


### PR DESCRIPTION
I commented out tests related to the boolean value user.delegating because it isn't updated in the delegation functions. There is a function called userDelegating that returns a boolean with the same meaning, so I am testing based on that. It might make sense to remove the "delegating" field from the User struct, since it's not needed. Alternatively, I think it should be kept up to date in the delegation functions.