### PR TITLE
Implement direct governance threshold in pool

### DIFF
--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -33,16 +33,33 @@ contract GetterUtils is DelegationUtils {
         return delegatedToAt(block.number, userAddress);
     }
 
-    function balanceOfAt(uint256 fromBlock, address userAddress)
+     function governanceSharesAt(uint256 fromBlock, address userAddress)
         public view returns (uint256)
     {
         if (userDelegatingAt(userAddress, fromBlock)) {
             return 0;
         }
-
         uint256 userSharesThen = sharesAt(fromBlock, userAddress);
         uint256 delegatedToUserThen = delegatedToAt(fromBlock, userAddress);
         return userSharesThen.add(delegatedToUserThen);
+    }
+
+    function governanceShares(address userAddress)
+        public view returns (uint256)
+    {
+        return governanceSharesAt(block.number, userAddress);
+    }
+
+    function balanceOfAt(uint256 fromBlock, address userAddress)
+        public view returns (uint256)
+    {
+        uint256 governanceSharesThen = governanceSharesAt(fromBlock, userAddress);
+        uint256 totalSharesThen = totalSupplyAt(fromBlock);
+        if (governanceSharesThen.mul(hundredPercent).div(totalSharesThen) < directGovernanceThreshold)
+        {
+            return 0;
+        }
+        return governanceSharesThen;
     }
 
     function balanceOf(address userAddress)

--- a/packages/pool/contracts/GovernanceUtils.sol
+++ b/packages/pool/contracts/GovernanceUtils.sol
@@ -13,6 +13,7 @@ contract GovernanceUtils is TimelockUtils {
     event NewMinApr(uint256 oldMin, uint256 newMin);
     event NewUnstakeWaitPeriod(uint256 oldPeriod, uint256 newPeriod);
     event NewUpdateCoefficient(uint256 oldCoeff, uint256 newCoeff);
+    event NewDirectGovernanceThreshold(uint256 oldThreshold, uint256 newThreshold);
     event NewClaimsManager(address oldClaimsManager, address claimsManager);
 
     function setStakeTarget(uint256 _stakeTarget)
@@ -62,6 +63,16 @@ contract GovernanceUtils is TimelockUtils {
         uint256 oldCoeff = updateCoeff;
         updateCoeff = _updateCoeff;
         emit NewUpdateCoefficient(oldCoeff, updateCoeff);
+    }
+
+    function setDirectGovernanceThreshold(uint256 _directGovernanceThreshold)
+        external
+        //onlyDao
+    {
+        require(_directGovernanceThreshold <= 100000000 && _directGovernanceThreshold >= 0, "Invalid value");
+        uint256 oldDirectGovernanceThreshold = directGovernanceThreshold;
+        directGovernanceThreshold = _directGovernanceThreshold;
+        emit NewDirectGovernanceThreshold(oldDirectGovernanceThreshold, directGovernanceThreshold);
     }
 
     function setClaimsManager(address _claimsManager)

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -57,6 +57,7 @@ contract StateUtils {
     uint256 public stakeTarget = 10e6 ether;
     uint256 public updateCoeff = 1000000;
     uint256 public unstakeWaitPeriod = rewardEpochLength;
+    uint256 public directGovernanceThreshold = 100000;
 
     uint256 public currentApr = minApr;
 


### PR DESCRIPTION
Implements a direct governance threshold at the pool. This is an easier implementation of the proposal threshold to prevent spam, but also prevents voting when the staker is below the threshold.
Also added `governanceShares` getters that may come in handy for the dashboard, etc.
