### PR TITLE
Do not keep totalStake in checkpoints

### DIFF
--- a/packages/pool/contracts/ClaimUtils.sol
+++ b/packages/pool/contracts/ClaimUtils.sol
@@ -35,15 +35,9 @@ contract ClaimUtils is StakeUtils, IClaimUtils {
         payEpochRewardBefore()
         onlyClaimsManager()
     {
-        uint256 totalStakedNow = getValue(totalStaked);
-        // We need `totalStakedNow` to be greater than `amount` because we 
-        // always need at least 1 Wei staked to avoid division by zero errors
-        require(totalStakedNow > amount, ERROR_VALUE);
-        uint256 totalStakedAfter = totalStakedNow - amount;
-        totalStaked.push(Checkpoint({
-            fromBlock: block.number,
-            value: totalStakedAfter
-            }));
+        // totalStake should not go lower than 1
+        require(totalStake > amount, ERROR_VALUE);
+        totalStake = totalStake - amount;
         api3Token.transfer(recipient, amount);
         emit PaidOutClaim(
             recipient,

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -77,29 +77,6 @@ contract GetterUtils is StateUtils, IGetterUtils {
         return totalSupplyAt(block.number);
     }
 
-    /// @notice Called to get the total staked tokens at a specific block
-    /// @param fromBlock Block number for which the query is being made for
-    /// @return Total staked tokens at the block
-    function totalStakeAt(uint256 fromBlock)
-        public
-        view
-        override
-        returns(uint256)
-    {
-        return getValueAt(totalStaked, fromBlock);
-    }
-
-    /// @notice Called to get the current total staked tokens
-    /// @return Current total staked tokens
-    function totalStake()
-        public
-        view
-        override
-        returns(uint256)
-    {
-        return totalStakeAt(block.number);
-    }
-
     /// @notice Called to get the pool shares of a user at a specific block
     /// @param fromBlock Block number for which the query is being made for
     /// @param userAddress User address
@@ -128,22 +105,6 @@ contract GetterUtils is StateUtils, IGetterUtils {
         return userSharesAt(block.number, userAddress);
     }
 
-    /// @notice Called to get the staked tokens of the user at a specific block
-    /// @param fromBlock Block number for which the query is being made for
-    /// @param userAddress User address
-    /// @return Staked tokens of the user at the block
-    function userStakeAt(
-        uint256 fromBlock,
-        address userAddress
-        )
-        public
-        view
-        override
-        returns(uint256)
-    {
-        return userSharesAt(fromBlock, userAddress) * totalStakeAt(fromBlock) / totalSupplyAt(fromBlock);
-    }
-
     /// @notice Called to get the current staked tokens of the user
     /// @param userAddress User address
     /// @return Current staked tokens of the user
@@ -153,7 +114,7 @@ contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        return userStakeAt(block.number, userAddress);
+        return userShares(userAddress) * totalStake / totalSupply();
     }
 
     /// @notice Called to get the voting power delegated to a user at a

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -82,8 +82,8 @@ contract StateUtils is IStateUtils {
     /// @notice User records
     mapping(address => User) public users;
 
-    /// @notice Total number of tokens staked at the pool, kept in checkpoints
-    Checkpoint[] public totalStaked;
+    /// @notice Total number of tokens staked at the pool
+    uint256 public totalStake;
 
     /// @notice Total number of shares at the pool, kept in checkpoints
     Checkpoint[] public totalShares;
@@ -159,10 +159,7 @@ contract StateUtils is IStateUtils {
             fromBlock: block.number,
             value: 1
             }));
-        totalStaked.push(Checkpoint({
-            fromBlock: block.number,
-            value: 1
-            }));
+        totalStake = 1;
         // Set the current epoch as the genesis epoch and skip its reward
         // payment
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -27,16 +27,6 @@ interface IGetterUtils is IStateUtils {
         view
         returns(uint256);
 
-    function totalStakeAt(uint256 fromBlock)
-        external
-        view
-        returns(uint256);
-
-    function totalStake()
-        external
-        view
-        returns(uint256);
-
     function userSharesAt(
         uint256 fromBlock,
         address userAddress
@@ -46,14 +36,6 @@ interface IGetterUtils is IStateUtils {
         returns(uint256);
 
     function userShares(address userAddress)
-        external
-        view
-        returns(uint256);
-
-    function userStakeAt(
-        uint256 fromBlock,
-        address userAddress
-        )
         external
         view
         returns(uint256);


### PR DESCRIPTION
Although `totalStaked` is being kept as a checkpoint array
https://github.com/api3dao/api3-dao/blob/612021f4162e5a0e1c88cd3b61924c6f67976d4b/packages/pool/contracts/StateUtils.sol#L86
[`totalStakeAt`](https://github.com/api3dao/api3-dao/blob/612021f4162e5a0e1c88cd3b61924c6f67976d4b/packages/pool/contracts/GetterUtils.sol#L83) is not called anywhere, so it's wasteful.
Now it's being kept in a single variable, which reduces gas costs and simplifies the contract.