### PR TITLE
Remove schedule unstake penalty

### DIFF
--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -31,7 +31,6 @@ contract StateUtils is IStateUtils {
         uint256 lastDelegationUpdateTimestamp;
         uint256 unstakeScheduledFor;
         uint256 unstakeAmount;
-        mapping(uint256 => bool) epochIndexToRewardRevocationStatus;
     }
 
     string constant internal ERROR_VALUE = "Invalid value";

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -32,6 +32,41 @@ beforeEach(async () => {
   epochLength = await api3Pool.EPOCH_LENGTH();
 });
 
+describe("userSharesAt", function () {
+  it("gets user shares at", async function () {
+    const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
+    await api3Token
+      .connect(roles.deployer)
+      .approve(api3Pool.address, user1Stake);
+    await api3Pool
+      .connect(roles.randomPerson)
+      .deposit(roles.deployer.address, user1Stake, roles.user1.address);
+    await api3Pool
+      .connect(roles.user1)
+      .stake(ethers.BigNumber.from(1));
+    await api3Pool
+      .connect(roles.user1)
+      .stake(ethers.BigNumber.from(1));
+    await api3Pool
+      .connect(roles.user1)
+      .stake(ethers.BigNumber.from(1));
+    const currentBlockNumber = await ethers.provider.getBlockNumber();
+    expect(
+      await api3Pool.userSharesAt(currentBlockNumber, roles.user1.address)
+    ).to.equal(ethers.BigNumber.from(3));
+    expect(
+      await api3Pool.userSharesAt(currentBlockNumber - 1, roles.user1.address)
+    ).to.equal(ethers.BigNumber.from(2));
+    expect(
+      await api3Pool.userSharesAt(currentBlockNumber - 2, roles.user1.address)
+    ).to.equal(ethers.BigNumber.from(1));
+    expect(
+      await api3Pool.userSharesAt(currentBlockNumber - 3, roles.user1.address)
+    ).to.equal(ethers.BigNumber.from(0));
+  });
+});
+
+
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
     const firstBlockNumber = await ethers.provider.getBlockNumber();

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -150,348 +150,41 @@ describe("depositAndStake", function () {
 
 describe("scheduleUnstake", function () {
   context("User has enough staked to schedule unstake", function () {
-    context(
-      "User's reward for this epoch has not been revoked due to an earlier unstake scheduling",
-      function () {
-        context("Reward has been paid this epoch", function () {
-          context("User has received the reward", function () {
-            context("User still has the reward", function () {
-              it("revokes this epoch's reward and schedules unstake", async function () {
-                // Authorize pool contract to mint tokens
-                await api3Token
-                  .connect(roles.deployer)
-                  .updateMinterStatus(api3Pool.address, true);
-                // Have two users stake
-                const user1Stake = ethers.utils.parseEther(
-                  "10" + "000" + "000"
-                );
-                const user2Stake = ethers.utils.parseEther(
-                  "30" + "000" + "000"
-                );
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user1.address, user1Stake);
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user2.address, user2Stake);
-                await api3Token
-                  .connect(roles.user1)
-                  .approve(api3Pool.address, user1Stake);
-                await api3Token
-                  .connect(roles.user2)
-                  .approve(api3Pool.address, user2Stake);
-                await api3Pool
-                  .connect(roles.user1)
-                  .depositAndStake(
-                    roles.user1.address,
-                    user1Stake,
-                    roles.user1.address
-                  );
-                await api3Pool
-                  .connect(roles.user2)
-                  .depositAndStake(
-                    roles.user2.address,
-                    user2Stake,
-                    roles.user2.address
-                  );
-                // Fast forward time to one epoch into the future
-                const genesisEpoch = await api3Pool.genesisEpoch();
-                const genesisEpochPlusOne = genesisEpoch.add(
-                  ethers.BigNumber.from(1)
-                );
-                await ethers.provider.send("evm_setNextBlockTimestamp", [
-                  genesisEpochPlusOne.mul(epochLength).toNumber(),
-                ]);
-                // Pay reward
-                await api3Pool.connect(roles.randomPerson).payReward();
-                const userStakeAfterReward = await api3Pool.userStake(
-                  roles.user1.address
-                );
-                // The `payReward()` above adds one tick to the timestamp
-                const unstakeScheduledFor = genesisEpochPlusOne
-                  .mul(epochLength)
-                  .add(epochLength)
-                  .add(ethers.BigNumber.from(1));
-                // Schedule unstake
-                await expect(
-                  api3Pool.connect(roles.user1).scheduleUnstake(user1Stake)
-                )
-                  .to.emit(api3Pool, "ScheduledUnstake")
-                  .withArgs(
-                    roles.user1.address,
-                    user1Stake,
-                    unstakeScheduledFor
-                  );
-                const userStakeAfterPenalty = await api3Pool.userStake(
-                  roles.user1.address
-                );
-                const userReward = userStakeAfterReward.sub(user1Stake);
-                const userPenalty = userStakeAfterReward.sub(
-                  userStakeAfterPenalty
-                );
-                expect(userReward).to.equal(userPenalty);
-              });
-            });
-            context("User no longer has the reward", function () {
-              it("reverts", async function () {
-                // Authorize pool contract to mint tokens
-                await api3Token
-                  .connect(roles.deployer)
-                  .updateMinterStatus(api3Pool.address, true);
-                // Have the user stake
-                const user1Stake = ethers.utils.parseEther(
-                  "10" + "000" + "000"
-                );
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user1.address, user1Stake);
-                await api3Token
-                  .connect(roles.user1)
-                  .approve(api3Pool.address, user1Stake);
-                await api3Pool
-                  .connect(roles.user1)
-                  .depositAndStake(
-                    roles.user1.address,
-                    user1Stake,
-                    roles.user1.address
-                  );
-                // Fast forward time to one epoch into the future
-                const genesisEpoch = await api3Pool.genesisEpoch();
-                const genesisEpochPlusOne = genesisEpoch.add(
-                  ethers.BigNumber.from(1)
-                );
-                await ethers.provider.send("evm_setNextBlockTimestamp", [
-                  genesisEpochPlusOne.mul(epochLength).toNumber(),
-                ]);
-                // Pay reward
-                await api3Pool.connect(roles.randomPerson).payReward();
-                // Set the DAO Agent
-                await api3Pool
-                  .connect(roles.randomPerson)
-                  .setDaoAgent(roles.daoAgent.address);
-                // Set claims manager status as true with the DAO Agent
-                await api3Pool
-                  .connect(roles.daoAgent)
-                  .setClaimsManagerStatus(roles.claimsManager.address, true);
-                // Pay out the entire pool for a claim
-                await api3Pool
-                  .connect(roles.claimsManager)
-                  .payOutClaim(
-                    roles.claimsManager.address,
-                    (await api3Token.balanceOf(api3Pool.address)).sub(
-                      ethers.BigNumber.from(1)
-                    )
-                  );
-                await expect(
-                  api3Pool
-                    .connect(roles.user1)
-                    .scheduleUnstake(
-                      await api3Pool.userStake(roles.user1.address)
-                    )
-                ).to.be.revertedWith("Unauthorized");
-              });
-            });
-          });
-          context("User has not received the reward", function () {
-            it("schedules unstake", async function () {
-              // Authorize pool contract to mint tokens
-              await api3Token
-                .connect(roles.deployer)
-                .updateMinterStatus(api3Pool.address, true);
-              // Have two users stake
-              const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
-              const user2Stake = ethers.utils.parseEther("30" + "000" + "000");
-              await api3Token
-                .connect(roles.deployer)
-                .transfer(roles.user1.address, user1Stake);
-              await api3Token
-                .connect(roles.deployer)
-                .transfer(roles.user2.address, user2Stake);
-              await api3Token
-                .connect(roles.user1)
-                .approve(api3Pool.address, user1Stake);
-              await api3Token
-                .connect(roles.user2)
-                .approve(api3Pool.address, user2Stake);
-              await api3Pool
-                .connect(roles.user2)
-                .depositAndStake(
-                  roles.user2.address,
-                  user2Stake,
-                  roles.user2.address
-                );
-              // Fast forward time to one epoch into the future
-              const genesisEpoch = await api3Pool.genesisEpoch();
-              const genesisEpochPlusOne = genesisEpoch.add(
-                ethers.BigNumber.from(1)
-              );
-              await ethers.provider.send("evm_setNextBlockTimestamp", [
-                genesisEpochPlusOne.mul(epochLength).toNumber(),
-              ]);
-              // Pay reward
-              await api3Pool.connect(roles.randomPerson).payReward();
-              // Have user 1 stake after the reward payment
-              await api3Pool
-                .connect(roles.user1)
-                .depositAndStake(
-                  roles.user1.address,
-                  user1Stake,
-                  roles.user1.address
-                );
-              // The transactions above add two ticks to the timestamp
-              const unstakeScheduledFor = genesisEpochPlusOne
-                .mul(epochLength)
-                .add(epochLength)
-                .add(ethers.BigNumber.from(2));
-              // Schedule unstake
-              const userStakeBeforePenalty = await api3Pool.userStake(
-                roles.user1.address
-              );
-              await expect(
-                api3Pool
-                  .connect(roles.user1)
-                  .scheduleUnstake(userStakeBeforePenalty)
-              )
-                .to.emit(api3Pool, "ScheduledUnstake")
-                .withArgs(
-                  roles.user1.address,
-                  userStakeBeforePenalty,
-                  unstakeScheduledFor
-                );
-              const userStakeAfterPenalty = await api3Pool.userStake(
-                roles.user1.address
-              );
-              const userPenalty = userStakeBeforePenalty.sub(
-                userStakeAfterPenalty
-              );
-              expect(userPenalty).to.equal(ethers.BigNumber.from(0));
-            });
-          });
-        });
-        context("Reward has not been paid this epoch", function () {
-          it("schedules unstake", async function () {
-            // Have the user stake
-            const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user1.address, user1Stake);
-            await api3Token
-              .connect(roles.user1)
-              .approve(api3Pool.address, user1Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            const genesisEpoch = await api3Pool.genesisEpoch();
-            const genesisEpochPlusOne = genesisEpoch.add(
-              ethers.BigNumber.from(1)
-            );
-            await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusOne.mul(epochLength).toNumber(),
-            ]);
-            // Skip the reward payment
-            const unstakeScheduledFor = genesisEpochPlusOne
-              .mul(epochLength)
-              .add(epochLength);
-            // Schedule unstake
-            const userStakeBeforePenalty = await api3Pool.userStake(
-              roles.user1.address
-            );
-            await expect(
-              api3Pool.connect(roles.user1).scheduleUnstake(user1Stake)
-            )
-              .to.emit(api3Pool, "ScheduledUnstake")
-              .withArgs(roles.user1.address, user1Stake, unstakeScheduledFor);
-            const userStakeAfterPenalty = await api3Pool.userStake(
-              roles.user1.address
-            );
-            const userPenalty = userStakeBeforePenalty.sub(
-              userStakeAfterPenalty
-            );
-            expect(userPenalty).to.equal(ethers.BigNumber.from(0));
-          });
-        });
-      }
-    );
-    context(
-      "User's reward for this epoch has been revoked due to an earlier unstake scheduling",
-      function () {
-        it("schedules unstake", async function () {
-          // Authorize pool contract to mint tokens
-          await api3Token
-            .connect(roles.deployer)
-            .updateMinterStatus(api3Pool.address, true);
-          // Have two users stake
-          const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
-          const user2Stake = ethers.utils.parseEther("30" + "000" + "000");
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user1.address, user1Stake);
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user2.address, user2Stake);
-          await api3Token
-            .connect(roles.user1)
-            .approve(api3Pool.address, user1Stake);
-          await api3Token
-            .connect(roles.user2)
-            .approve(api3Pool.address, user2Stake);
-          await api3Pool
-            .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake,
-              roles.user1.address
-            );
-          await api3Pool
-            .connect(roles.user2)
-            .depositAndStake(
-              roles.user2.address,
-              user2Stake,
-              roles.user2.address
-            );
-          // Fast forward time to one epoch into the future
-          const genesisEpoch = await api3Pool.genesisEpoch();
-          const genesisEpochPlusOne = genesisEpoch.add(
-            ethers.BigNumber.from(1)
-          );
-          await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpochPlusOne.mul(epochLength).toNumber(),
-          ]);
-          // Pay reward
-          await api3Pool.connect(roles.randomPerson).payReward();
-          // Schedule unstake
-          await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
-          // The transactions above add two ticks to the timestamp
-          const unstakeScheduledFor = genesisEpochPlusOne
-            .mul(epochLength)
-            .add(epochLength)
-            .add(ethers.BigNumber.from(2));
-          const userStakeBeforePenalty = await api3Pool.userStake(
-            roles.user1.address
-          );
-          await expect(
-            api3Pool
-              .connect(roles.user1)
-              .scheduleUnstake(userStakeBeforePenalty)
-          )
-            .to.emit(api3Pool, "ScheduledUnstake")
-            .withArgs(
-              roles.user1.address,
-              userStakeBeforePenalty,
-              unstakeScheduledFor
-            );
-          const userStakeAfterPenalty = await api3Pool.userStake(
-            roles.user1.address
-          );
-          const userPenalty = userStakeBeforePenalty.sub(userStakeAfterPenalty);
-          expect(userPenalty).to.equal(ethers.BigNumber.from(0));
-        });
-      }
-    );
+    it("schedules unstake", async function () {
+      // Have the user stake
+      const user1Stake = ethers.utils.parseEther(
+        "10" + "000" + "000"
+      );
+      await api3Token
+        .connect(roles.deployer)
+        .transfer(roles.user1.address, user1Stake);
+      await api3Token
+        .connect(roles.user1)
+        .approve(api3Pool.address, user1Stake);
+      await api3Pool
+        .connect(roles.user1)
+        .depositAndStake(
+          roles.user1.address,
+          user1Stake,
+          roles.user1.address
+        );
+      const currentBlock = await ethers.provider.getBlock(
+        await ethers.provider.getBlockNumber()
+      );
+      const unstakeScheduledFor = ethers.BigNumber.from(currentBlock.timestamp)
+        .add(epochLength)
+        .add(ethers.BigNumber.from(1));
+      // Schedule unstake
+      await expect(
+        api3Pool.connect(roles.user1).scheduleUnstake(user1Stake)
+      )
+        .to.emit(api3Pool, "ScheduledUnstake")
+        .withArgs(
+          roles.user1.address,
+          user1Stake,
+          unstakeScheduledFor
+        );
+    });
   });
   context("User does not have enough staked to schedule unstake", function () {
     it("reverts", async function () {


### PR DESCRIPTION
I have been questioning the user being penalized for scheduling an unstake already and the audit report pushed me over the edge (referred to in https://github.com/api3dao/api3-dao/issues/137). I think the trade-off is not worth it so I removed it. See comments for details.