### PR TITLE
Do not keep totalShares in checkpoints

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -260,11 +260,11 @@ contract Api3Voting is IForwarder, AragonApp {
         require(userAddressToLastNewProposalTimestamp[msg.sender].add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         userAddressToLastNewProposalTimestamp[msg.sender] = now;
 
-        uint64 snapshotBlock = getBlockNumber64(); // avoid double voting in this very block
+        uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
 
         uint256 votingPower = api3Pool.totalSupply();
         require(votingPower > 0, ERROR_NO_VOTING_POWER);
-        uint256 proposalMakerVotingPower = api3Pool.balanceOf(msg.sender);
+        uint256 proposalMakerVotingPower = api3Pool.balanceOfAt(msg.sender, snapshotBlock);
         require(
             proposalMakerVotingPower >= votingPower.mul(api3Pool.proposalVotingPowerThreshold()).div(1e8),
             "API3_HIT_PROPOSAL_THRESHOLD"

--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -260,11 +260,11 @@ contract Api3Voting is IForwarder, AragonApp {
         require(userAddressToLastNewProposalTimestamp[msg.sender].add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         userAddressToLastNewProposalTimestamp[msg.sender] = now;
 
-        uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
+        uint64 snapshotBlock = getBlockNumber64(); // avoid double voting in this very block
 
-        uint256 votingPower = api3Pool.totalSupplyAt(snapshotBlock);
+        uint256 votingPower = api3Pool.totalSupply();
         require(votingPower > 0, ERROR_NO_VOTING_POWER);
-        uint256 proposalMakerVotingPower = api3Pool.balanceOfAt(msg.sender, snapshotBlock);
+        uint256 proposalMakerVotingPower = api3Pool.balanceOf(msg.sender);
         require(
             proposalMakerVotingPower >= votingPower.mul(api3Pool.proposalVotingPowerThreshold()).div(1e8),
             "API3_HIT_PROPOSAL_THRESHOLD"

--- a/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
+++ b/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
@@ -20,7 +20,12 @@ interface IApi3Pool {
         view
         returns(uint256);
 
-    function totalSupplyAt(uint256 fromBlock)
+    function balanceOf(address userAddress)
+        external
+        view
+        returns(uint256);
+
+    function totalSupply()
         external
         view
         returns(uint256);

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -56,12 +56,4 @@ contract Api3TokenMock is MiniMeToken {
     {
         return mockProposalVotingPowerThreshold;
     }
-
-    function totalStakeAt(uint256 snapshotBlock)
-        external
-        view
-        returns(uint256)
-    {
-        return super.totalSupplyAt(snapshotBlock);
-    }
 }

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -185,7 +185,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
           assert.isTrue(open, 'vote should be open');
           assert.isFalse(executed, 'vote should not be executed');
           assert.equal(creator, holder51, 'creator should be correct');
-          assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
+          assertBn(snapshotBlock, await web3.eth.getBlockNumber(), 'snapshot block should be correct');
           assertBn(supportRequired, neededSupport, 'required support should be app required support');
           assertBn(minAcceptQuorum, minimumAcceptanceQuorum, 'min quorum should be app min quorum');
           assertBn(yea, 0, 'initial yea should be 0');
@@ -450,7 +450,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       const { snapshotBlock, votingPower } = await voting.getVote(voteId);
 
       // Generating tokens advanced the block by one
-      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 2, 'snapshot block should be correct');
+      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
       assertBn(votingPower, await token.totalSupplyAt(snapshotBlock), 'voting power should match snapshot supply');
       assertBn(votingPower, 2, 'voting power should be correct')
     });
@@ -462,9 +462,9 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       const voteId = createdVoteId(await voting.newTokenAndVote(holder2, 1, 'metadata'));
 
       const { snapshotBlock, votingPower } = await voting.getVote(voteId);
-      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
+      assertBn(snapshotBlock, await web3.eth.getBlockNumber(), 'snapshot block should be correct');
       assertBn(votingPower, await token.totalSupplyAt(snapshotBlock), 'voting power should match snapshot supply');
-      assertBn(votingPower, 2, 'voting power should be correct')
+      assertBn(votingPower, 3, 'voting power should be correct')
     })
   });
 

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -185,7 +185,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
           assert.isTrue(open, 'vote should be open');
           assert.isFalse(executed, 'vote should not be executed');
           assert.equal(creator, holder51, 'creator should be correct');
-          assertBn(snapshotBlock, await web3.eth.getBlockNumber(), 'snapshot block should be correct');
+          assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
           assertBn(supportRequired, neededSupport, 'required support should be app required support');
           assertBn(minAcceptQuorum, minimumAcceptanceQuorum, 'min quorum should be app min quorum');
           assertBn(yea, 0, 'initial yea should be 0');
@@ -450,7 +450,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       const { snapshotBlock, votingPower } = await voting.getVote(voteId);
 
       // Generating tokens advanced the block by one
-      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
+      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1 - 1, 'snapshot block should be correct');
       assertBn(votingPower, await token.totalSupplyAt(snapshotBlock), 'voting power should match snapshot supply');
       assertBn(votingPower, 2, 'voting power should be correct')
     });
@@ -462,8 +462,8 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       const voteId = createdVoteId(await voting.newTokenAndVote(holder2, 1, 'metadata'));
 
       const { snapshotBlock, votingPower } = await voting.getVote(voteId);
-      assertBn(snapshotBlock, await web3.eth.getBlockNumber(), 'snapshot block should be correct');
-      assertBn(votingPower, await token.totalSupplyAt(snapshotBlock), 'voting power should match snapshot supply');
+      assertBn(snapshotBlock, await web3.eth.getBlockNumber() - 1, 'snapshot block should be correct');
+      assertBn(votingPower, (await token.totalSupplyAt(snapshotBlock)).add(bn(1)), 'voting power should match snapshot supply');
       assertBn(votingPower, 3, 'voting power should be correct')
     })
   });

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -50,20 +50,6 @@ contract GetterUtils is StateUtils, IGetterUtils {
         return balanceOfAt(userAddress, block.number);
     }
 
-    /// @notice Called to get the total voting power at a specific block
-    /// @dev This method is used to implement the MiniMe interface for the
-    /// Aragon Voting app
-    /// @param fromBlock Block number for which the query is being made for
-    /// @return Total voting power at the block
-    function totalSupplyAt(uint256 fromBlock)
-        public
-        view
-        override
-        returns(uint256)
-    {
-        return getValueAt(totalShares, fromBlock);
-    }
-
     /// @notice Called to get the current total voting power
     /// @dev This method is used to implement the MiniMe interface for the
     /// Aragon Voting app
@@ -74,7 +60,7 @@ contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        return totalSupplyAt(block.number);
+        return totalShares;
     }
 
     /// @notice Called to get the pool shares of a user at a specific block

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -79,7 +79,7 @@ contract RewardUtils is GetterUtils, IRewardUtils {
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: block.number,
                     amount: rewardAmount,
-                    totalSharesThen: getValue(totalShares)
+                    totalSharesThen: totalShares
                     });
                 if (rewardAmount > 0) {
                     api3Token.mint(address(this), rewardAmount);

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -84,8 +84,8 @@ contract StateUtils is IStateUtils {
     /// @notice Total number of tokens staked at the pool
     uint256 public totalStake;
 
-    /// @notice Total number of shares at the pool, kept in checkpoints
-    Checkpoint[] public totalShares;
+    /// @notice Total number of shares at the pool
+    uint256 public totalShares;
 
     // All percentage values are represented by multiplying by 1e6
     uint256 internal constant ONE_PERCENT = 1_000_000;
@@ -154,10 +154,7 @@ contract StateUtils is IStateUtils {
     {
         api3Token = IApi3Token(api3TokenAddress);
         // Initialize the share price at 1
-        totalShares.push(Checkpoint({
-            fromBlock: block.number,
-            value: 1
-            }));
+        totalShares = 1;
         totalStake = 1;
         // Set the current epoch as the genesis epoch and skip its reward
         // payment

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -17,11 +17,6 @@ interface IGetterUtils is IStateUtils {
         view
         returns(uint256);
 
-    function totalSupplyAt(uint256 fromBlock)
-        external
-        view
-        returns(uint256);
-
     function totalSupply()
         external
         view


### PR DESCRIPTION
If we remove the schedule unstake penalty (https://github.com/api3dao/api3-dao/pull/134), `getValueAt(totalShares, ...)` doesn't get called anywhere. Then, similar to converting `totalStake` from `Checkpoint[]` to `uint256` (https://github.com/api3dao/api3-dao/pull/131), we can convert `totalShares` from `Checkpoint[]` to `uint256`.

...but there is a caveat. Api3-Voting calls `balanceOfAt()`, which calls `getValueAt(totalShares, block.number - 1)`. In this PR, I updated the vote snapshot block number from `block.number - 1` to `block.number` and replaced `balanceOfAt()` with `balanceOf()`. I don't see the significance of setting the snapshot at the previous block, so I'm opening this PR to get you guys' opinion (and I think there are slightly more convoluted ways of keeping the snapshot at the previous block, but it feels like this would work just as well).