### PR TITLE
Overwrite checkpoints where possible

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -269,6 +269,7 @@ contract Api3Voting is IForwarder, AragonApp {
             proposalMakerVotingPower >= votingPower.mul(api3Pool.proposalVotingPowerThreshold()).div(1e8),
             "API3_HIT_PROPOSAL_THRESHOLD"
             );
+        api3Pool.updateLastVoteSnapshotBlock(snapshotBlock);
 
         voteId = votesLength++;
 

--- a/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
+++ b/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
@@ -24,4 +24,7 @@ interface IApi3Pool {
         external
         view
         returns(uint256);
+
+    function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
+        external;
 }

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -64,4 +64,9 @@ contract Api3TokenMock is MiniMeToken {
     {
         return totalSupplyAt(block.number - 1);
     }
+
+    function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
+        external
+    {
+    }
 }

--- a/packages/api3-voting/test/delegation-integration.js
+++ b/packages/api3-voting/test/delegation-integration.js
@@ -66,6 +66,8 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
 
             await token.approve(pool.address, balance3, {from:voter3});
             await pool.depositAndStake(voter3, balance3, voter3, {from:voter3});
+
+            await pool.setVotingApps([voting.address]);
         });
 
         it('delegate to myself or to 0 address', async () => {

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -48,6 +48,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
     beforeEach(async () => {
       token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true); // empty parameters minime
       api3Pool = await Api3Pool.new(token.address);
+      await api3Pool.setVotingApps([voting.address]);
 
       await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration);
       executionTarget = await ExecutionTarget.new()
@@ -106,6 +107,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       beforeEach(async () => {
         token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', decimals, 'n', true); // empty parameters minime
         api3Pool = await Api3Pool.new(token.address);
+        await api3Pool.setVotingApps([voting.address]);
 
         await token.generateTokens(holder20, bigExp(20, decimals));
         await token.generateTokens(holder29, bigExp(29, decimals));

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -42,22 +42,22 @@ contract DelegationUtils is RewardUtils, IDelegationUtils {
         if (userDelegate != address(0)) {
             // Need to revoke previous delegation
             User storage prevDelegate = users[userDelegate];
-            prevDelegate.delegatedTo.push(Checkpoint({
-                fromBlock: block.number,
-                value: getValue(prevDelegate.delegatedTo) - userShares
-                }));
+            updateCheckpointArray(
+                prevDelegate.delegatedTo,
+                getValue(prevDelegate.delegatedTo) - userShares
+                );
         }
         // Assign the new delegation
         User storage _delegate = users[delegate];
-        _delegate.delegatedTo.push(Checkpoint({
-            fromBlock: block.number,
-            value: getValue(_delegate.delegatedTo) + userShares
-            }));
+        updateCheckpointArray(
+            _delegate.delegatedTo,
+            getValue(_delegate.delegatedTo) + userShares
+            );
         // Record the new delegate for the user
-        user.delegates.push(AddressCheckpoint({
-            fromBlock: block.number,
-            _address: delegate
-            }));
+        updateAddressCheckpointArray(
+            user.delegates,
+            delegate
+            );
         emit Delegated(
             msg.sender,
             delegate
@@ -79,14 +79,14 @@ contract DelegationUtils is RewardUtils, IDelegationUtils {
 
         uint256 userShares = getValue(user.shares);
         User storage delegate = users[userDelegate];
-        delegate.delegatedTo.push(Checkpoint({
-            fromBlock: block.number,
-            value: getValue(delegate.delegatedTo) - userShares
-            }));
-        user.delegates.push(AddressCheckpoint({
-            fromBlock: block.number,
-            _address: address(0)
-            }));
+        updateCheckpointArray(
+            delegate.delegatedTo,
+            getValue(delegate.delegatedTo) - userShares
+            );
+        updateAddressCheckpointArray(
+            user.delegates,
+            address(0)
+            );
         user.lastDelegationUpdateTimestamp = block.timestamp;
         emit Undelegated(
             msg.sender,
@@ -122,9 +122,9 @@ contract DelegationUtils is RewardUtils, IDelegationUtils {
                 ? currentlyDelegatedTo - shares
                 : 0;
         }
-        delegate.delegatedTo.push(Checkpoint({
-            fromBlock: block.number,
-            value: newDelegatedTo
-            }));
+        updateCheckpointArray(
+            delegate.delegatedTo,
+            newDelegatedTo
+            );
     }
 }

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -77,4 +77,9 @@ interface IStateUtils {
         string calldata specsUrl
         )
         external;
+
+
+
+    function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
+        external;
 }

--- a/packages/pool/contracts/mock/MockApi3Voting.sol
+++ b/packages/pool/contracts/mock/MockApi3Voting.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.2;
+
+import "../interfaces/IApi3Pool.sol";
+
+contract MockApi3Voting {
+    IApi3Pool public api3Pool;
+
+    constructor(address _api3Pool)
+    {
+        api3Pool = IApi3Pool(_api3Pool);
+    }
+
+    function newVote()
+        external
+    {
+        api3Pool.updateLastVoteSnapshotBlock(block.number - 1);
+    }
+}


### PR DESCRIPTION
Note: The code is a bit disorganized, I wanted to get an opinion first.

With this PR, updates to checkpoint arrays overwrite the last element instead of adding a new element to the array. New elements get added only once after an authorized voting app notifies the pool contract of a new vote. This is implemented for `user.delegatedTo`, `user.delegates` but not `user.shares`.

Along with the following upcoming PRs, this will resolve any potential issues regarding these two checkpoint arrays:
1. In `userReceivedDelegationAt()` and `userDelegateAt()`, instead of binary search, start from the end and search backwards one by one (as here, we are looking for a value from the last week)
2. Revert transactions that will add a new element to `user.delegatedTo` or `user.delegates` that result in more than N elements (N=10?) being added to the checkpoint array in the last week (note that this requires 10 proposals within a week and transactions between each of them, which is very unlikely). Note that this may also result in https://github.com/api3dao/api3-dao/blob/4405a48fa0097ea60a47c56c4e0ae6e30e779ea5/packages/pool/contracts/StakeUtils.sol#L118 reverting, which is bad but unavoidable imo. Also, in the search in PR-1 (the one above), only search through the last N elements.

Note that `user.shares` is omitted in this PR, as we need its checkpoint updates even if no new votes are being created due to 
https://github.com/api3dao/api3-dao/blob/4405a48fa0097ea60a47c56c4e0ae6e30e779ea5/packages/pool/contracts/RewardUtils.sol#L126
(we can also only update `user.shares` only after a reward is paid out but this is probably not worth it because `user.shares` will likely not be updated 1+ times a week)

The planned solution for this has two steps:
1. Instead of doing a binary search for each reward lock, start from the beginning and search `user.shares` one by one to find all 52 checkpoints. After a `withdrawal()`, record the checkpoint index of the first lock to start the search from that index for the following interactions.
2. To further optimize 1, implement a function to be statically called to return the 52 checkpoint indices that will point to `user.shares` at reward lock ups. `withdraw()` will then be called with this array, costing less and a deterministic amount of gas.

Implementing all of these eliminates all binary searches and results in deterministic gas cost limits for all interactions. None of these include any garbage collection, but that only optimizes the general case and doesn't protect against non-deterministic gas costs.