### PR TITLE
Reduce constructor() inheritance chain from 8 steps to 1 (#150)

### DIFF
--- a/packages/pool/contracts/Api3Pool.sol
+++ b/packages/pool/contracts/Api3Pool.sol
@@ -25,6 +25,6 @@ import "./interfaces/IApi3Pool.sol";
 contract Api3Pool is TimelockUtils, IApi3Pool {
     /// @param api3TokenAddress API3 token contract address
     constructor(address api3TokenAddress)
-        TimelockUtils(api3TokenAddress)
+        StateUtils(api3TokenAddress)
     {}
 }

--- a/packages/pool/contracts/ClaimUtils.sol
+++ b/packages/pool/contracts/ClaimUtils.sol
@@ -5,17 +5,12 @@ import "./StakeUtils.sol";
 import "./interfaces/IClaimUtils.sol";
 
 /// @title Contract that implements the insurance claim payout functionality
-contract ClaimUtils is StakeUtils, IClaimUtils {
+abstract contract ClaimUtils is StakeUtils, IClaimUtils {
     /// @dev Reverts if the caller is not a claims manager
     modifier onlyClaimsManager() {
         require(claimsManagerStatus[msg.sender], ERROR_UNAUTHORIZED);
         _;
     }
-
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        StakeUtils(api3TokenAddress)
-    {}
 
     /// @notice Called by a claims manager to pay out an insurance claim
     /// @dev The claims manager is a trusted contract that is allowed to

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -5,12 +5,7 @@ import "./RewardUtils.sol";
 import "./interfaces/IDelegationUtils.sol";
 
 /// @title Contract that implements voting power delegation
-contract DelegationUtils is RewardUtils, IDelegationUtils {
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        RewardUtils(api3TokenAddress)
-    {}
-
+abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
     /// @notice Called by the user to delegate voting power
     /// @param delegate User address the voting power will be delegated to
     function delegateVotingPower(address delegate) 

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -5,12 +5,7 @@ import "./StateUtils.sol";
 import "./interfaces/IGetterUtils.sol";
 
 /// @title Contract that implements getters
-contract GetterUtils is StateUtils, IGetterUtils {
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        StateUtils(api3TokenAddress)
-    {}
-
+abstract contract GetterUtils is StateUtils, IGetterUtils {
     /// @notice Called to get the voting power of a user at a specific block
     /// @dev This method is used to implement the MiniMe interface for the
     /// Api3Voting app

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -5,12 +5,7 @@ import "./GetterUtils.sol";
 import "./interfaces/IRewardUtils.sol";
 
 /// @title Contract that implements reward payments and locks
-contract RewardUtils is GetterUtils, IRewardUtils {
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        GetterUtils(api3TokenAddress)
-    {}
-
+abstract contract RewardUtils is GetterUtils, IRewardUtils {
     /// @notice Called to pay the reward for the current epoch
     /// @dev Skips past epochs for which rewards have not been paid for.
     /// Skips the reward payment if the pool is not authorized to mint tokens.

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -5,12 +5,7 @@ import "./TransferUtils.sol";
 import "./interfaces/IStakeUtils.sol";
 
 /// @title Contract that implements staking functionality
-contract StakeUtils is TransferUtils, IStakeUtils {
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        TransferUtils(api3TokenAddress)
-    {}
-
+abstract contract StakeUtils is TransferUtils, IStakeUtils {
     /// @notice Called to stake tokens to receive pools in the share
     /// @param amount Amount of tokens to stake
     function stake(uint256 amount)

--- a/packages/pool/contracts/TimelockUtils.sol
+++ b/packages/pool/contracts/TimelockUtils.sol
@@ -7,7 +7,7 @@ import "./interfaces/ITimelockUtils.sol";
 /// @title Contract that implements vesting functionality
 /// @dev TimelockManager contracts interface with this contract to transfer
 /// API3 tokens that are locked under a vesting schedule.
-contract TimelockUtils is ClaimUtils, ITimelockUtils {
+abstract contract TimelockUtils is ClaimUtils, ITimelockUtils {
     struct Timelock
     {
         uint256 totalAmount;
@@ -23,11 +23,6 @@ contract TimelockUtils is ClaimUtils, ITimelockUtils {
     /// acceptable, because the TimelockManager is implemented in a way to not
     /// allow multiple timelocks per user.
     mapping(address => mapping(address => Timelock)) public userToDepositorToTimelock;
-
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        ClaimUtils(api3TokenAddress)
-    {}
 
     /// @notice Called by TimelockManager contracts to deposit tokens on behalf
     /// of a user on a linear vesting schedule

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -5,12 +5,7 @@ import "./DelegationUtils.sol";
 import "./interfaces/ITransferUtils.sol";
 
 /// @title Contract that implements token transfer functionality
-contract TransferUtils is DelegationUtils, ITransferUtils {
-    /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        DelegationUtils(api3TokenAddress)
-    {}
-
+abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     /// @notice Called to deposit tokens for a user by using `transferFrom()`
     /// @dev This method is used by `TimelockManager.sol`
     /// @param source Token transfer source


### PR DESCRIPTION
`Api3Pool` has a linear inheritance chain of 8 superclasses (many more if you include interfaces too).  The constructor was delegating to every single parent along the chain, which locked this inheritance chain into this linear sequence, preventing any refactoring of the class hierarchy into simpler structures.  However seven of the constructors did nothing but delegate construction to their parent.

So remove all the intermediaries by making `Api3Pool`'s constructor delegate directly to `StateUtils`'s constructor.  This will allow further refactorings of the class hierarchy in subsequent commits.

This is an initial step towards addressing #150.