### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[**.sol]
+indent_style = space
+indent_size = 4
+
+[**.js{,on}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This should help make sure whitespace indentation is consistent in an editor-agnostic way, using the standard described at:

  https://editorconfig.org/