### PR TITLE
Update reward scheme

### DIFF
--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -45,40 +45,20 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
     function updateCurrentApr()
         internal
     {
-        if (stakeTarget == 0) {
-            currentApr = minApr;
-            return;
-        }
         uint256 totalStakePercentage = totalStake
-             * HUNDRED_PERCENT
+            * HUNDRED_PERCENT
             / api3Token.totalSupply();
-        // Calculate what % we are off from the target
-        uint256 deltaAbsolute = totalStakePercentage < stakeTarget 
-            ? stakeTarget - totalStakePercentage
-            : totalStakePercentage - stakeTarget;
-        uint256 deltaPercentage = deltaAbsolute * HUNDRED_PERCENT / stakeTarget;
-        // Use the update coefficient to calculate what % we need to update
-        // the APR with
-        uint256 aprUpdate = deltaPercentage * aprUpdateCoefficient / ONE_PERCENT;
-
-        uint256 newApr;
-        if (totalStakePercentage < stakeTarget) {
-            newApr = currentApr * (HUNDRED_PERCENT + aprUpdate) / HUNDRED_PERCENT;
+        if (totalStakePercentage > stakeTarget) {
+            currentApr = currentApr > aprUpdateStep ? currentApr - aprUpdateStep : 0;
         }
         else {
-            newApr = HUNDRED_PERCENT > aprUpdate
-                ? currentApr * (HUNDRED_PERCENT - aprUpdate) / HUNDRED_PERCENT
-                : 0;
+            currentApr += aprUpdateStep;
         }
-
-        if (newApr < minApr) {
-            currentApr = minApr;
-        }
-        else if (newApr > maxApr) {
+        if (currentApr > maxApr) {
             currentApr = maxApr;
         }
-        else {
-            currentApr = newApr;
+        else if (currentApr < minApr) {
+            currentApr = minApr;
         }
     }
 }

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -121,7 +121,7 @@ contract StateUtils is IStateUtils {
 
     /// @notice Stake target the pool will aim to meet in percentages of the
     /// total token supply. The staking rewards increase if the total staked
-    ///  amount is below this, and vice versa.
+    /// amount is below this, and vice versa.
     /// @dev Default value is 50% of the total API3 token supply. This
     /// parameter is governable by the DAO.
     uint256 public stakeTarget = 50_000_000;
@@ -136,12 +136,9 @@ contract StateUtils is IStateUtils {
     /// @dev Default value is 75%. This parameter is governable by the DAO.
     uint256 public maxApr = 75_000_000;
 
-    /// @notice Coefficient that represents how aggresively the APR will be
-    /// updated to meet the stake target.
-    /// @dev Since this is a coefficient, it has no unit. A coefficient of 1e6
-    /// means 1% deviation from the stake target results in 1% update in APR.
-    /// This parameter is governable by the DAO.
-    uint256 public aprUpdateCoefficient = 1_000_000;
+    /// @notice Steps in which APR will be updated in percentages
+    /// @dev Default value is 1%. This parameter is governable by the DAO.
+    uint256 public aprUpdateStep = 1_000_000;
 
     /// @notice Users need to schedule an unstake and wait for
     /// `unstakeWaitPeriod` before being able to unstake. This is to prevent
@@ -160,11 +157,10 @@ contract StateUtils is IStateUtils {
     uint256 public proposalVotingPowerThreshold = 100_000;
 
     /// @notice APR that will be paid next epoch
-    /// @dev This is initialized at maximum APR, but will reach an
-    /// equilibrium based on the stake target.
+    /// @dev This value will reach an equilibrium based on the stake target.
     /// Every epoch (week), APR/52 of the total staked tokens will be added to
     /// the pool, effectively distributing them to the stakers.
-    uint256 public currentApr = maxApr;
+    uint256 public currentApr = (maxApr + minApr) / 2;
 
     // Snapshot block number of the last vote created at one of the DAO
     // Api3Voting apps
@@ -342,23 +338,19 @@ contract StateUtils is IStateUtils {
             );
     }
 
-    /// @notice Called by the DAO Agent to set the APR update coefficient
-    /// @param _aprUpdateCoefficient APR update coefficient
-    function setAprUpdateCoefficient(uint256 _aprUpdateCoefficient)
+    /// @notice Called by the DAO Agent to set the APR update steps
+    /// @dev aprUpdateStep can be 0% or 100%+
+    /// @param _aprUpdateStep APR update steps
+    function setAprUpdateStep(uint256 _aprUpdateStep)
         external
         override
         onlyAgentApp()
     {
-        require(
-            _aprUpdateCoefficient <= 1_000_000_000
-                && _aprUpdateCoefficient > 0,
-            ERROR_VALUE
-            );
-        uint256 oldAprUpdateCoefficient = aprUpdateCoefficient;
-        aprUpdateCoefficient = _aprUpdateCoefficient;
-        emit SetAprUpdateCoefficient(
-            oldAprUpdateCoefficient,
-            aprUpdateCoefficient
+        uint256 oldAprUpdateStep = aprUpdateStep;
+        aprUpdateStep = _aprUpdateStep;
+        emit SetAprUpdateStep(
+            oldAprUpdateStep,
+            aprUpdateStep
             );
     }
 

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -34,9 +34,9 @@ interface IStateUtils {
         uint256 unstakeWaitPeriod
         );
 
-    event SetAprUpdateCoefficient(
-        uint256 oldAprUpdateCoefficient,
-        uint256 aprUpdateCoefficient
+    event SetAprUpdateStep(
+        uint256 oldAprUpdateStep,
+        uint256 aprUpdateStep
         );
 
     event SetProposalVotingPowerThreshold(
@@ -83,7 +83,7 @@ interface IStateUtils {
     function setUnstakeWaitPeriod(uint256 _unstakeWaitPeriod)
         external;
 
-    function setAprUpdateCoefficient(uint256 _aprUpdateCoefficient)
+    function setAprUpdateStep(uint256 _aprUpdateStep)
         external;
 
     function setProposalVotingPowerThreshold(uint256 _proposalVotingPowerThreshold)

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -243,10 +243,10 @@ describe("delegateVotingPower", function () {
                 ]);
                 // ... then have user 1 delegate to user 2 again
                 await expect(
-                api3Pool
-                  .connect(roles.user1)
-                  .delegateVotingPower(roles.user2.address)
-                 ).to.be.revertedWith("Cannot delegate to the same address");
+                  api3Pool
+                    .connect(roles.user1)
+                    .delegateVotingPower(roles.user2.address)
+                ).to.be.revertedWith("Cannot delegate to the same address");
 
                 expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
                   ethers.BigNumber.from(0)

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -2,10 +2,6 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
-let EPOCH_LENGTH, REWARD_VESTING_PERIOD;
-
-const onePercent = ethers.BigNumber.from("1" + "000" + "000");
-const hundredPercent = ethers.BigNumber.from("100" + "000" + "000");
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -33,192 +29,293 @@ beforeEach(async () => {
     roles.deployer
   );
   api3Pool = await api3PoolFactory.deploy(api3Token.address);
-  EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
-  REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
 });
 
-describe("payReward", function () {
-  context("Reward for the previous epoch has not been paid", function () {
-    context("Pool contract is authorized to mint tokens", function () {
-      context("Stake target is not zero", function () {
-        context("Total stake is above target", function () {
-          it("updates APR and pays reward", async function () {
-            // Authorize pool contract to mint tokens
-            await api3Token
-              .connect(roles.deployer)
-              .updateMinterStatus(api3Pool.address, true);
-            // Have two users stake
-            const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-            const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user1.address, user1Stake);
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user2.address, user2Stake);
-            await api3Token
-              .connect(roles.user1)
-              .approve(api3Pool.address, user1Stake);
-            await api3Token
-              .connect(roles.user2)
-              .approve(api3Pool.address, user2Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            await api3Pool
-              .connect(roles.user2)
-              .depositAndStake(
-                roles.user2.address,
-                user2Stake,
-                roles.user2.address
-              );
-            // Fast forward time to one epoch into the future
-            const genesisEpoch = await api3Pool.genesisEpoch();
-            let nextEpoch = genesisEpoch;
-            // Pay rewards until APR is clipped at its minimum value
-            for (let ind = 0; ind < 5; ind++) {
-              nextEpoch = nextEpoch.add(ethers.BigNumber.from(1));
-              await ethers.provider.send("evm_setNextBlockTimestamp", [
-                nextEpoch.mul(EPOCH_LENGTH).toNumber(),
-              ]);
-              // Pay reward
-              const stakeTarget = await api3Pool.stakeTarget();
-              const totalStake = await api3Pool.totalStake();
-              const totalStakePercentage = totalStake
-                .mul(hundredPercent)
-                .div(await api3Token.totalSupply());
-              const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-              const deltaAbsolute = totalStakePercentage.sub(stakeTarget); // Over target
-              const deltaPercentage = deltaAbsolute
-                .mul(hundredPercent)
-                .div(stakeTarget);
-              const aprUpdate = deltaPercentage
-                .mul(aprUpdateCoefficient)
-                .div(onePercent);
-              const currentApr = await api3Pool.currentApr();
-              let newApr = currentApr
-                .mul(hundredPercent.sub(aprUpdate))
-                .div(hundredPercent);
-              if (newApr.lt(await api3Pool.minApr())) {
-                newApr = await api3Pool.minApr();
-              }
-              const rewardAmount = totalStake
-                .mul(newApr)
-                .div(REWARD_VESTING_PERIOD)
-                .div(hundredPercent);
-              await expect(api3Pool.connect(roles.randomPerson).payReward())
-                .to.emit(api3Pool, "PaidReward")
-                .withArgs(nextEpoch, rewardAmount, newApr);
-              expect(await api3Pool.totalStake()).to.equal(
-                totalStake.add(rewardAmount)
-              );
-              expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-                nextEpoch
-              );
-              expect(await api3Pool.currentApr()).to.equal(newApr);
-              const reward = await api3Pool.epochIndexToReward(nextEpoch);
-              expect(reward.atBlock).to.equal(
-                await ethers.provider.getBlockNumber()
-              );
-              expect(reward.amount).to.equal(rewardAmount);
-            }
-          });
-        });
-        context("Total stake is below target", function () {
-          it("updates APR and pays reward", async function () {
-            // Authorize pool contract to mint tokens
-            await api3Token
-              .connect(roles.deployer)
-              .updateMinterStatus(api3Pool.address, true);
-            // Have two users stake
-            const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
-            const user2Stake = ethers.utils.parseEther("30" + "000" + "000");
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user1.address, user1Stake);
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user2.address, user2Stake);
-            await api3Token
-              .connect(roles.user1)
-              .approve(api3Pool.address, user1Stake);
-            await api3Token
-              .connect(roles.user2)
-              .approve(api3Pool.address, user2Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            await api3Pool
-              .connect(roles.user2)
-              .depositAndStake(
-                roles.user2.address,
-                user2Stake,
-                roles.user2.address
-              );
-            // Fast forward time to one epoch into the future
-            const genesisEpoch = await api3Pool.genesisEpoch();
-            const genesisEpochPlusOne = genesisEpoch.add(
-              ethers.BigNumber.from(1)
-            );
-            await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-            ]);
-            // Pay reward
-            const stakeTarget = await api3Pool.stakeTarget();
-            const totalStake = await api3Pool.totalStake();
-            const totalStakePercentage = totalStake
-              .mul(hundredPercent)
-              .div(await api3Token.totalSupply());
-            const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-            const deltaAbsolute = stakeTarget.sub(totalStakePercentage); // Under target
-            const deltaPercentage = deltaAbsolute
-              .mul(hundredPercent)
-              .div(stakeTarget);
-            const aprUpdate = deltaPercentage
-              .mul(aprUpdateCoefficient)
-              .div(onePercent);
-            const currentApr = await api3Pool.currentApr();
-            let newApr = currentApr
-              .mul(hundredPercent.add(aprUpdate))
-              .div(hundredPercent);
-            if (newApr.gt(await api3Pool.maxApr())) {
-              newApr = await api3Pool.maxApr();
-            }
-            const rewardAmount = totalStake
-              .mul(newApr)
-              .div(REWARD_VESTING_PERIOD)
-              .div(hundredPercent);
-            await expect(api3Pool.connect(roles.randomPerson).payReward())
-              .to.emit(api3Pool, "PaidReward")
-              .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
-            expect(await api3Pool.totalStake()).to.equal(
-              totalStake.add(rewardAmount)
-            );
-            expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-              genesisEpochPlusOne
-            );
-            expect(await api3Pool.currentApr()).to.equal(newApr);
-            const reward = await api3Pool.epochIndexToReward(
-              genesisEpochPlusOne
-            );
-            expect(reward.atBlock).to.equal(
-              await ethers.provider.getBlockNumber()
-            );
-            expect(reward.amount).to.equal(rewardAmount);
-          });
-        });
+describe("constructor", function () {
+  it("initializes with the correct parameters", async function () {
+    // Epoch length is 7 days in seconds
+    expect(await api3Pool.EPOCH_LENGTH()).to.equal(
+      ethers.BigNumber.from(7 * 24 * 60 * 60)
+    );
+    // Reward vesting period is 52 week = 1 year
+    expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
+      ethers.BigNumber.from(52)
+    );
+    // Max interaction frequency is 20
+    expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
+      ethers.BigNumber.from(20)
+    );
+
+    // App addresses are not set
+    expect(await api3Pool.agentAppPrimary()).to.equal(
+      ethers.constants.AddressZero
+    );
+    expect(await api3Pool.agentAppSecondary()).to.equal(
+      ethers.constants.AddressZero
+    );
+    expect(await api3Pool.votingAppPrimary()).to.equal(
+      ethers.constants.AddressZero
+    );
+    expect(await api3Pool.votingAppSecondary()).to.equal(
+      ethers.constants.AddressZero
+    );
+    // Claims manager statuses are false by default
+    expect(
+      await api3Pool.claimsManagerStatus(roles.randomPerson.address)
+    ).to.equal(false);
+
+    // Verify the default DAO parameters
+    expect(await api3Pool.stakeTarget()).to.equal(
+      ethers.BigNumber.from("50" + "000" + "000")
+    );
+    expect(await api3Pool.minApr()).to.equal(
+      ethers.BigNumber.from("2" + "500" + "000")
+    );
+    expect(await api3Pool.maxApr()).to.equal(
+      ethers.BigNumber.from("75" + "000" + "000")
+    );
+    expect(await api3Pool.aprUpdateStep()).to.equal(
+      ethers.BigNumber.from("1" + "000" + "000")
+    );
+    expect(await api3Pool.unstakeWaitPeriod()).to.equal(
+      await api3Pool.EPOCH_LENGTH()
+    );
+    expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
+      ethers.BigNumber.from("100" + "000")
+    );
+    // Initialize the APR at (maxApr / minApr) / 2
+    expect(await api3Pool.currentApr()).to.equal(
+      (await api3Pool.maxApr()).add(await api3Pool.minApr()).div(2)
+    );
+
+    // Token address set correctly
+    expect(await api3Pool.api3Token()).to.equal(api3Token.address);
+    // Initialize share price at 1
+    expect(await api3Pool.totalSupply()).to.equal(ethers.BigNumber.from(1));
+    expect(await api3Pool.totalStake()).to.equal(ethers.BigNumber.from(1));
+    // Genesis epoch is the current epoch
+    const currentBlock = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber()
+    );
+    const currentEpoch = ethers.BigNumber.from(currentBlock.timestamp).div(
+      await api3Pool.EPOCH_LENGTH()
+    );
+    expect(await api3Pool.genesisEpoch()).to.equal(currentEpoch);
+    // Skip the reward payment of the genesis epoch
+    expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
+      await api3Pool.genesisEpoch()
+    );
+  });
+});
+
+describe("setDaoApps", function () {
+  context("DAO apps are not set before", function () {
+    context("DAO app addresses to be set are not zero", function () {
+      it("sets DAO apps", async function () {
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        )
+          .to.emit(api3Pool, "SetDaoApps")
+          .withArgs(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
+          );
+        expect(await api3Pool.agentAppPrimary()).to.equal(
+          roles.agentAppPrimary.address
+        );
+        expect(await api3Pool.agentAppSecondary()).to.equal(
+          roles.agentAppSecondary.address
+        );
+        expect(await api3Pool.votingAppPrimary()).to.equal(
+          roles.votingAppPrimary.address
+        );
+        expect(await api3Pool.votingAppSecondary()).to.equal(
+          roles.votingAppSecondary.address
+        );
       });
-      context("Stake target is zero", function () {
-        it("sets APR to minimum and pays reward", async function () {
-          // Set the stake target to zero
+    });
+    context("DAO app addresses to be set are zero", function () {
+      it("reverts", async function () {
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              ethers.constants.AddressZero,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        ).to.be.revertedWith("Invalid address");
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              ethers.constants.AddressZero,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        ).to.be.revertedWith("Invalid address");
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              ethers.constants.AddressZero,
+              roles.votingAppSecondary.address
+            )
+        ).to.be.revertedWith("Invalid address");
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              ethers.constants.AddressZero
+            )
+        ).to.be.revertedWith("Invalid address");
+      });
+    });
+  });
+  context("DAO apps are set before", function () {
+    context("Caller is primary Agent", function () {
+      it("sets DAO apps", async function () {
+        // Set the apps beforehand
+        await api3Pool
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.randomPerson.address,
+            roles.randomPerson.address,
+            roles.randomPerson.address
+          );
+        // Set the apps again as the primary Agent
+        await expect(
+          api3Pool
+            .connect(roles.agentAppPrimary)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        )
+          .to.emit(api3Pool, "SetDaoApps")
+          .withArgs(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
+          );
+        expect(await api3Pool.agentAppPrimary()).to.equal(
+          roles.agentAppPrimary.address
+        );
+        expect(await api3Pool.agentAppSecondary()).to.equal(
+          roles.agentAppSecondary.address
+        );
+        expect(await api3Pool.votingAppPrimary()).to.equal(
+          roles.votingAppPrimary.address
+        );
+        expect(await api3Pool.votingAppSecondary()).to.equal(
+          roles.votingAppSecondary.address
+        );
+      });
+    });
+    context("Caller is a random person", function () {
+      it("reverts", async function () {
+        // Set the apps beforehand
+        await api3Pool
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.randomPerson.address,
+            roles.randomPerson.address,
+            roles.randomPerson.address
+          );
+        // Attempt to set the apps again as a random person
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        ).to.be.revertedWith("Unauthorized");
+      });
+    });
+  });
+});
+
+describe("setClaimsManagerStatus", function () {
+  context("Caller is primary Agent", function () {
+    it("sets claims manager status", async function () {
+      await api3Pool
+        .connect(roles.randomPerson)
+        .setDaoApps(
+          roles.agentAppPrimary.address,
+          roles.agentAppSecondary.address,
+          roles.votingAppPrimary.address,
+          roles.votingAppSecondary.address
+        );
+      // Set claims manager status as true with the DAO Agent
+      await expect(
+        api3Pool
+          .connect(roles.agentAppPrimary)
+          .setClaimsManagerStatus(roles.claimsManager.address, true)
+      )
+        .to.emit(api3Pool, "SetClaimsManagerStatus")
+        .withArgs(roles.claimsManager.address, true);
+      expect(
+        await api3Pool.claimsManagerStatus(roles.claimsManager.address)
+      ).to.equal(true);
+      // Reset claims manager status as false with the DAO Agent
+      await expect(
+        api3Pool
+          .connect(roles.agentAppPrimary)
+          .setClaimsManagerStatus(roles.claimsManager.address, false)
+      )
+        .to.emit(api3Pool, "SetClaimsManagerStatus")
+        .withArgs(roles.claimsManager.address, false);
+      expect(
+        await api3Pool.claimsManagerStatus(roles.claimsManager.address)
+      ).to.equal(false);
+    });
+  });
+  context("Caller is not primary Agent", function () {
+    it("reverts", async function () {
+      await expect(
+        api3Pool
+          .connect(roles.agentAppSecondary)
+          .setClaimsManagerStatus(roles.claimsManager.address, false)
+      ).to.be.revertedWith("Unauthorized");
+      await expect(
+        api3Pool
+          .connect(roles.randomPerson)
+          .setClaimsManagerStatus(roles.claimsManager.address, false)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("setStakeTarget", function () {
+  context("Caller is Agent", function () {
+    context(
+      "Stake target to be set is smaller than or equal to 100,000,000",
+      function () {
+        it("sets stake target", async function () {
           await api3Pool
             .connect(roles.randomPerson)
             .setDaoApps(
@@ -227,290 +324,421 @@ describe("payReward", function () {
               roles.votingAppPrimary.address,
               roles.votingAppSecondary.address
             );
-          await api3Pool
-            .connect(roles.agentAppSecondary)
-            .setStakeTarget(ethers.BigNumber.from(0));
-          // Authorize pool contract to mint tokens
-          await api3Token
-            .connect(roles.deployer)
-            .updateMinterStatus(api3Pool.address, true);
-          // Have the user stake
-          const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user1.address, user1Stake);
-          await api3Token
-            .connect(roles.user1)
-            .approve(api3Pool.address, user1Stake);
-          await api3Pool
-            .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake,
-              roles.user1.address
-            );
-          // Fast forward time to one epoch into the future
-          const genesisEpoch = await api3Pool.genesisEpoch();
-          const genesisEpochPlusOne = genesisEpoch.add(
-            ethers.BigNumber.from(1)
-          );
-          await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-          ]);
-          // Pay reward
-          const totalStake = await api3Pool.totalStake();
-          const newApr = await api3Pool.minApr();
-          const rewardAmount = totalStake
-            .mul(newApr)
-            .div(REWARD_VESTING_PERIOD)
-            .div(hundredPercent);
-          await expect(api3Pool.connect(roles.randomPerson).payReward())
-            .to.emit(api3Pool, "PaidReward")
-            .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
-          expect(await api3Pool.totalStake()).to.equal(
-            totalStake.add(rewardAmount)
-          );
-          expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-            genesisEpochPlusOne
-          );
-          expect(await api3Pool.currentApr()).to.equal(newApr);
-          const reward = await api3Pool.epochIndexToReward(genesisEpochPlusOne);
-          expect(reward.atBlock).to.equal(
-            await ethers.provider.getBlockNumber()
-          );
-          expect(reward.amount).to.equal(rewardAmount);
+          const oldStakeTarget = await api3Pool.stakeTarget();
+          const newStakeTarget = ethers.BigNumber.from(123);
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setStakeTarget(newStakeTarget)
+          )
+            .to.emit(api3Pool, "SetStakeTarget")
+            .withArgs(oldStakeTarget, newStakeTarget);
+          expect(await api3Pool.stakeTarget()).to.equal(newStakeTarget);
+          await expect(
+            api3Pool
+              .connect(roles.agentAppSecondary)
+              .setStakeTarget(newStakeTarget)
+          )
+            .to.emit(api3Pool, "SetStakeTarget")
+            .withArgs(newStakeTarget, newStakeTarget);
+          expect(await api3Pool.stakeTarget()).to.equal(newStakeTarget);
         });
-      });
-    });
-    context("Pool contract is not authorized to mint tokens", function () {
-      it("skips the payment and APR update", async function () {
-        // Have two users stake
-        const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-        const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user1.address, user1Stake);
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user2.address, user2Stake);
-        await api3Token
-          .connect(roles.user1)
-          .approve(api3Pool.address, user1Stake);
-        await api3Token
-          .connect(roles.user2)
-          .approve(api3Pool.address, user2Stake);
+      }
+    );
+    context("Stake target to be set is larger than 100,000,000", function () {
+      it("reverts", async function () {
         await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
           );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
-        // Fast forward time to one epoch into the future
-        const genesisEpoch = await api3Pool.genesisEpoch();
-        const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));
-        await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-        ]);
-        // Pay reward
-        const totalStake = await api3Pool.totalStake();
-        const currentApr = await api3Pool.currentApr();
-        await api3Pool.connect(roles.randomPerson).payReward();
-        expect(await api3Pool.totalStake()).to.equal(totalStake);
-        expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-          genesisEpochPlusOne
-        );
-        expect(await api3Pool.currentApr()).to.equal(currentApr);
-        const reward = await api3Pool.epochIndexToReward(genesisEpochPlusOne);
-        expect(reward.atBlock).to.equal(0);
-        expect(reward.amount).to.equal(0);
+        const newStakeTarget = ethers.BigNumber.from("200" + "000" + "000");
+        await expect(
+          api3Pool
+            .connect(roles.agentAppSecondary)
+            .setStakeTarget(newStakeTarget)
+        ).to.be.revertedWith("Invalid value");
       });
     });
   });
-  context("Rewards for multiple epochs have not been paid", function () {
-    context("Pool contract is authorized to mint tokens", function () {
-      it("updates APR and only pays the reward for the current epoch", async function () {
-        // Authorize pool contract to mint tokens
-        await api3Token
-          .connect(roles.deployer)
-          .updateMinterStatus(api3Pool.address, true);
-        // Have two users stake
-        const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-        const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user1.address, user1Stake);
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user2.address, user2Stake);
-        await api3Token
-          .connect(roles.user1)
-          .approve(api3Pool.address, user1Stake);
-        await api3Token
-          .connect(roles.user2)
-          .approve(api3Pool.address, user2Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
-        // Fast forward time to five epochs into the future
-        const genesisEpoch = await api3Pool.genesisEpoch();
-        const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
-        await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
-        ]);
-        // Pay reward
-        const stakeTarget = await api3Pool.stakeTarget();
-        const totalStake = await api3Pool.totalStake();
-        const totalStakePercentage = totalStake
-          .mul(hundredPercent)
-          .div(await api3Token.totalSupply());
-        const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-        const deltaAbsolute = totalStakePercentage.sub(stakeTarget); // Over target
-        const deltaPercentage = deltaAbsolute
-          .mul(hundredPercent)
-          .div(stakeTarget);
-        const aprUpdate = deltaPercentage
-          .mul(aprUpdateCoefficient)
-          .div(onePercent);
-        const currentApr = await api3Pool.currentApr();
-        const newApr = currentApr
-          .mul(hundredPercent.sub(aprUpdate))
-          .div(hundredPercent);
-        const rewardAmount = totalStake
-          .mul(newApr)
-          .div(REWARD_VESTING_PERIOD)
-          .div(hundredPercent);
-        await expect(api3Pool.connect(roles.randomPerson).payReward())
-          .to.emit(api3Pool, "PaidReward")
-          .withArgs(genesisEpochPlusFive, rewardAmount, newApr);
-        expect(await api3Pool.totalStake()).to.equal(
-          totalStake.add(rewardAmount)
-        );
-        expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-          genesisEpochPlusFive
-        );
-        expect(await api3Pool.currentApr()).to.equal(newApr);
-        const reward = await api3Pool.epochIndexToReward(genesisEpochPlusFive);
-        expect(reward.atBlock).to.equal(await ethers.provider.getBlockNumber());
-        expect(reward.amount).to.equal(rewardAmount);
-      });
+  context("Caller is not DAO Agent", function () {
+    it("reverts", async function () {
+      const newStakeTarget = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool.connect(roles.randomPerson).setStakeTarget(newStakeTarget)
+      ).to.be.revertedWith("Unauthorized");
     });
-    context("Pool contract is not authorized to mint tokens", function () {
-      it("skips the payment and APR update", async function () {
-        // Have two users stake
-        const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-        const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user1.address, user1Stake);
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(roles.user2.address, user2Stake);
-        await api3Token
-          .connect(roles.user1)
-          .approve(api3Pool.address, user1Stake);
-        await api3Token
-          .connect(roles.user2)
-          .approve(api3Pool.address, user2Stake);
+  });
+});
+
+describe("setMaxApr", function () {
+  context("Caller is DAO Agent", function () {
+    context(
+      "Max APR to be set is larger than or equal to min APR",
+      function () {
+        it("sets max APR", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const oldMaxApr = await api3Pool.maxApr();
+          const minApr = await api3Pool.minApr();
+          const newMaxApr = minApr.add(ethers.BigNumber.from(123));
+          await expect(
+            api3Pool.connect(roles.agentAppPrimary).setMaxApr(newMaxApr)
+          )
+            .to.emit(api3Pool, "SetMaxApr")
+            .withArgs(oldMaxApr, newMaxApr);
+          expect(await api3Pool.maxApr()).to.equal(newMaxApr);
+          await expect(
+            api3Pool.connect(roles.agentAppSecondary).setMaxApr(newMaxApr)
+          )
+            .to.emit(api3Pool, "SetMaxApr")
+            .withArgs(newMaxApr, newMaxApr);
+          expect(await api3Pool.maxApr()).to.equal(newMaxApr);
+        });
+      }
+    );
+    context("Max APR to be set is smaller than min APR", function () {
+      it("reverts", async function () {
         await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
           );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
-        // Fast forward time to five epochs into the future
-        const genesisEpoch = await api3Pool.genesisEpoch();
-        const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
-        await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
-        ]);
-        // Pay reward
-        const totalStake = await api3Pool.totalStake();
-        const currentApr = await api3Pool.currentApr();
-        await api3Pool.connect(roles.randomPerson).payReward();
-        expect(await api3Pool.totalStake()).to.equal(totalStake);
-        expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-          genesisEpochPlusFive
-        );
-        expect(await api3Pool.currentApr()).to.equal(currentApr);
-        const reward = await api3Pool.epochIndexToReward(genesisEpochPlusFive);
-        expect(reward.atBlock).to.equal(0);
-        expect(reward.amount).to.equal(0);
+        const minApr = await api3Pool.minApr();
+        const newMaxApr = minApr.sub(ethers.BigNumber.from(123));
+        await expect(
+          api3Pool.connect(roles.agentAppSecondary).setMaxApr(newMaxApr)
+        ).to.be.revertedWith("Invalid value");
       });
     });
   });
-  context("Reward for the current epoch has been paid", function () {
-    it("does nothing", async function () {
-      // Authorize pool contract to mint tokens
-      await api3Token
-        .connect(roles.deployer)
-        .updateMinterStatus(api3Pool.address, true);
-      // Have two users stake
-      const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-      const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-      await api3Token
-        .connect(roles.deployer)
-        .transfer(roles.user1.address, user1Stake);
-      await api3Token
-        .connect(roles.deployer)
-        .transfer(roles.user2.address, user2Stake);
-      await api3Token
-        .connect(roles.user1)
-        .approve(api3Pool.address, user1Stake);
-      await api3Token
-        .connect(roles.user2)
-        .approve(api3Pool.address, user2Stake);
+  context("Caller is not DAO Agent", function () {
+    it("reverts", async function () {
+      const newMaxApr = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool.connect(roles.randomPerson).setMaxApr(newMaxApr)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("setMinApr", function () {
+  context("Caller is DAO Agent", function () {
+    context(
+      "Min APR to be set is smaller than or equal to max APR",
+      function () {
+        it("sets min APR", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const oldMinApr = await api3Pool.minApr();
+          const maxApr = await api3Pool.maxApr();
+          const newMinApr = maxApr.sub(ethers.BigNumber.from(123));
+          await expect(
+            api3Pool.connect(roles.agentAppPrimary).setMinApr(newMinApr)
+          )
+            .to.emit(api3Pool, "SetMinApr")
+            .withArgs(oldMinApr, newMinApr);
+          expect(await api3Pool.minApr()).to.equal(newMinApr);
+          await expect(
+            api3Pool.connect(roles.agentAppSecondary).setMinApr(newMinApr)
+          )
+            .to.emit(api3Pool, "SetMinApr")
+            .withArgs(newMinApr, newMinApr);
+          expect(await api3Pool.minApr()).to.equal(newMinApr);
+        });
+      }
+    );
+    context("Min APR to be set is larger than max APR", function () {
+      it("reverts", async function () {
+        await api3Pool
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
+          );
+        const maxApr = await api3Pool.maxApr();
+        const newMinApr = maxApr.add(ethers.BigNumber.from(123));
+        await expect(
+          api3Pool.connect(roles.agentAppSecondary).setMinApr(newMinApr)
+        ).to.be.revertedWith("Invalid value");
+      });
+    });
+  });
+  context("Caller is not DAO Agent", function () {
+    it("reverts", async function () {
+      const newMinApr = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool.connect(roles.randomPerson).setMinApr(newMinApr)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("setUnstakeWaitPeriod", function () {
+  context("Caller is primary DAO Agent", function () {
+    context(
+      "Unstake wait period to be set is larger than or equal to epoch length",
+      function () {
+        it("sets unstake wait period", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const oldUnstakeWaitPeriod = await api3Pool.unstakeWaitPeriod();
+          const epochLength = await api3Pool.EPOCH_LENGTH();
+          const newUnstakeWaitPeriod = epochLength.add(
+            ethers.BigNumber.from(123)
+          );
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setUnstakeWaitPeriod(newUnstakeWaitPeriod)
+          )
+            .to.emit(api3Pool, "SetUnstakeWaitPeriod")
+            .withArgs(oldUnstakeWaitPeriod, newUnstakeWaitPeriod);
+          expect(await api3Pool.unstakeWaitPeriod()).to.equal(
+            newUnstakeWaitPeriod
+          );
+        });
+      }
+    );
+    context(
+      "Unstake wait period to be set is smaller than epoch length",
+      function () {
+        it("reverts", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const epochLength = await api3Pool.EPOCH_LENGTH();
+          const newUnstakeWaitPeriod = epochLength.sub(
+            ethers.BigNumber.from(123)
+          );
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setUnstakeWaitPeriod(newUnstakeWaitPeriod)
+          ).to.be.revertedWith("Invalid value");
+        });
+      }
+    );
+  });
+  context("Caller is not primary DAO Agent", function () {
+    it("reverts", async function () {
+      const newUnstakeWaitPeriod = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool
+          .connect(roles.agentAppSecondary)
+          .setUnstakeWaitPeriod(newUnstakeWaitPeriod)
+      ).to.be.revertedWith("Unauthorized");
+      await expect(
+        api3Pool
+          .connect(roles.randomPerson)
+          .setUnstakeWaitPeriod(newUnstakeWaitPeriod)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("setAprUpdateStep", function () {
+  context("Caller is DAO Agent", function () {
+    it("sets APR update coefficient", async function () {
       await api3Pool
-        .connect(roles.user1)
-        .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+        .connect(roles.randomPerson)
+        .setDaoApps(
+          roles.agentAppPrimary.address,
+          roles.agentAppSecondary.address,
+          roles.votingAppPrimary.address,
+          roles.votingAppSecondary.address
+        );
+      const oldAprUpdateStep = await api3Pool.aprUpdateStep();
+      const newAprUpdateStep = ethers.BigNumber.from("500" + "000");
+      await expect(
+        api3Pool
+          .connect(roles.agentAppPrimary)
+          .setAprUpdateStep(newAprUpdateStep)
+      )
+        .to.emit(api3Pool, "SetAprUpdateStep")
+        .withArgs(oldAprUpdateStep, newAprUpdateStep);
+      expect(await api3Pool.aprUpdateStep()).to.equal(newAprUpdateStep);
+    });
+  });
+  context("Caller is not DAO Agent", function () {
+    it("reverts", async function () {
+      const newAprUpdateCoefficient = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool
+          .connect(roles.randomPerson)
+          .setAprUpdateStep(newAprUpdateCoefficient)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("setProposalVotingPowerThreshold", function () {
+  context("Caller is primary DAO Agent", function () {
+    context(
+      "Proposal voting power threshold to be set is smaller than or equal to 10,000,000",
+      function () {
+        it("sets proposal voting power threshold", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const oldProposalVotingPowerThreshold = await api3Pool.proposalVotingPowerThreshold();
+          const newProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "1" + "000" + "000"
+          );
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+          )
+            .to.emit(api3Pool, "SetProposalVotingPowerThreshold")
+            .withArgs(
+              oldProposalVotingPowerThreshold,
+              newProposalVotingPowerThreshold
+            );
+          expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
+            newProposalVotingPowerThreshold
+          );
+        });
+      }
+    );
+    context(
+      "Proposal voting power threshold to be set is larger than 10,000,000",
+      function () {
+        it("reverts", async function () {
+          await api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            );
+          const newProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "50" + "000" + "000"
+          );
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+          ).to.be.revertedWith("Invalid value");
+        });
+      }
+    );
+  });
+  context("Caller is not primary DAO Agent", function () {
+    it("reverts", async function () {
+      const newProposalVotingPowerThreshold = ethers.BigNumber.from(123);
+      await expect(
+        api3Pool
+          .connect(roles.agentAppSecondary)
+          .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+      ).to.be.revertedWith("Unauthorized");
+      await expect(
+        api3Pool
+          .connect(roles.randomPerson)
+          .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+});
+
+describe("updateLastVoteSnapshotBlock", function () {
+  context("Caller is a Voting app", function () {
+    it("updates lastVoteSnapshotBlock", async function () {
       await api3Pool
-        .connect(roles.user2)
-        .depositAndStake(roles.user2.address, user2Stake, roles.user2.address);
-      // Fast forward time to one epoch into the future
-      const genesisEpoch = await api3Pool.genesisEpoch();
-      const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));
-      await ethers.provider.send("evm_setNextBlockTimestamp", [
-        genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-      ]);
-      // Pay reward
-      await api3Pool.connect(roles.randomPerson).payReward();
-      const totalStake = await api3Pool.totalStake();
-      const epochIndexOfLastRewardPayment = await api3Pool.epochIndexOfLastRewardPayment();
-      const currentApr = await api3Pool.currentApr();
-      // Pay reward again
-      await api3Pool.connect(roles.randomPerson).payReward();
-      // Nothing should have changed
-      expect(await api3Pool.totalStake()).to.equal(totalStake);
-      expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-        epochIndexOfLastRewardPayment
+        .connect(roles.randomPerson)
+        .setDaoApps(
+          roles.agentAppPrimary.address,
+          roles.agentAppSecondary.address,
+          roles.votingAppPrimary.address,
+          roles.votingAppSecondary.address
+        );
+      const currentBlock = await ethers.provider.getBlock(
+        await ethers.provider.getBlockNumber()
       );
-      expect(await api3Pool.currentApr()).to.equal(currentApr);
+      const snapshotBlockNumber = currentBlock.number;
+      const nextBlockTimestamp = currentBlock.timestamp + 100;
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        nextBlockTimestamp,
+      ]);
+      await expect(
+        api3Pool
+          .connect(roles.votingAppPrimary)
+          .updateLastVoteSnapshotBlock(snapshotBlockNumber)
+      )
+        .to.emit(api3Pool, "UpdatedLastVoteSnapshotBlock")
+        .withArgs(
+          roles.votingAppPrimary.address,
+          snapshotBlockNumber,
+          nextBlockTimestamp
+        );
+      const snapshotBlockNumber2 = currentBlock.number + 1;
+      const nextBlockTimestamp2 = currentBlock.timestamp + 200;
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        nextBlockTimestamp2,
+      ]);
+      await expect(
+        api3Pool
+          .connect(roles.votingAppSecondary)
+          .updateLastVoteSnapshotBlock(snapshotBlockNumber2)
+      )
+        .to.emit(api3Pool, "UpdatedLastVoteSnapshotBlock")
+        .withArgs(
+          roles.votingAppSecondary.address,
+          snapshotBlockNumber2,
+          nextBlockTimestamp2
+        );
+    });
+  });
+  context("Caller is not an authorized Api3Voting app", function () {
+    it("reverts", async function () {
+      await api3Pool
+        .connect(roles.randomPerson)
+        .setDaoApps(
+          roles.agentAppPrimary.address,
+          roles.agentAppSecondary.address,
+          roles.votingAppPrimary.address,
+          roles.votingAppSecondary.address
+        );
+      await expect(
+        api3Pool.connect(roles.randomPerson).updateLastVoteSnapshotBlock(123)
+      ).to.be.revertedWith("Unauthorized");
     });
   });
 });


### PR DESCRIPTION
I did some simulations and verified that the previous rewards were too oscillatory. I added a derivative term and achieved a stable result https://github.com/bbenligiray/rewards/blob/main/main.ipynb The problem with this approach is that the parameters (`Ki`, `Kd`) need to be chosen correctly and maintained to avoid oscillation. Doing this with DAO governance is not feasible.

This PR replaces the whole thing with the Livepeer scheme as suggested. Since it will result in the equilibrium to be reached slowly, `currentApr` is initialized at a lower value.