### PR TITLE
Use binary search to get the delegated voting power as necessary

### DIFF
--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -117,10 +117,8 @@ Since this will only happen voluntarily and will get resolved automatically simp
 
 Each time a user is delegated to/undelegated from, their `user.delegatedTo` will be updated.
 Furthermore, if there has been a proposal made since the last update, a new element will be added to the `Checkpoint` array.
-This array will be searched linearly when the delegated user calls `balanceOfAt()` to vote (for the last week).
-A concern here is that too many interleaved proposals and delegation updates may bloat the user's `delegatedTo` array for the last week and prevent them from voting.
-To prevent this from being used as an attack vector, a transaction cannot add more than `MAX_INTERACTION_FREQUENCY` (default value = `20`) elements to a user's `delegatedTo` in a week.
-The proposal spam protection mechanisms are expected to keep the number of proposals in a week well below `20` (and if they cannot, their parameters should be updated to reduce spam further).
+
+TODO: Update
 
 ## Double Agent and Api3Voting apps
 

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -139,11 +139,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
 
     /// @notice Called to get the voting power delegated to a user at a
     /// specific block
-    /// @dev Starts from the most recent value in `user.delegatedTo` and
-    /// searches backwards one element at a time. If `_block` is within
-    /// `EPOCH_LENGTH`, this call is guaranteed to find the value among
-    /// the last `MAX_INTERACTION_FREQUENCY` elements, which is why it only
-    /// searches through them. 
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Voting power delegated to the user at the block
@@ -157,10 +152,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns(uint256)
     {
         Checkpoint[] storage delegatedTo = users[userAddress].delegatedTo;
-        uint256 minimumCheckpointIndex = delegatedTo.length > MAX_INTERACTION_FREQUENCY
-            ? delegatedTo.length - MAX_INTERACTION_FREQUENCY
-            : 0;
-        return getValueAt(delegatedTo, _block, minimumCheckpointIndex);
+        return getValueAtWithBinarySearch(delegatedTo, _block, 0);
     }
 
     /// @notice Called to get the current voting power delegated to a user

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -356,6 +356,10 @@ contract StateUtils is IStateUtils {
     /// @notice Called by the DAO Agent to set the voting power threshold for
     /// proposals
     /// Only the primary Agent can do this because it is a critical operation.
+    /// @dev Proposal voting power is limited between 0.1% and 10%. 0.1% is to
+    /// ensure that no more than 1000 proposals can be made within an epoch
+    /// (see `userReceivedDelegationAt()`) and any value above 10% is certainly
+    /// an error.
     /// @param _proposalVotingPowerThreshold Voting power threshold for
     /// proposals
     function setProposalVotingPowerThreshold(uint256 _proposalVotingPowerThreshold)
@@ -364,7 +368,8 @@ contract StateUtils is IStateUtils {
         onlyAgentAppPrimary()
     {
         require(
-            _proposalVotingPowerThreshold <= 10 * ONE_PERCENT,
+            _proposalVotingPowerThreshold >= ONE_PERCENT / 10
+                && _proposalVotingPowerThreshold <= 10 * ONE_PERCENT,
             ERROR_VALUE);
         uint256 oldProposalVotingPowerThreshold = proposalVotingPowerThreshold;
         proposalVotingPowerThreshold = _proposalVotingPowerThreshold;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -46,24 +46,11 @@ contract StateUtils is IStateUtils {
     /// before `EPOCH_LENGTH` has passed
     /// (3) After a user updates their delegation status, they have to wait
     /// `EPOCH_LENGTH` before updating it again
-    /// (4) A user's `delegatedTo` or `delegates` checkpoint arrays can be
-    /// extended up to `MAX_INTERACTION_FREQUENCY` in an `EPOCH_LENGTH`
     uint256 public constant EPOCH_LENGTH = 7 * 24 * 60 * 60;
 
     /// @notice Number of epochs before the staking rewards get unlocked.
     /// Hardcoded as 52 epochs, which corresponds to a year.
     uint256 public constant REWARD_VESTING_PERIOD = 52;
-
-    /// @notice Maximum number of additions interactions can make to a specific
-    /// user's `delegatedTo` and `delegates` in an EPOCH_LENGTH before it
-    /// starts to revert
-    /// @dev Note that interactions overwrite checkpoints rather than adding a
-    /// new element to the arrays unless a new proposal is made between them.
-    /// This means that at least `MAX_INTERACTION_FREQUENCY` proposals need
-    /// to be made for this mechanism to prevent further interactions, which is
-    /// not likely to happen in practice due to the proposal spam protection
-    /// mechanisms.
-    uint256 public constant MAX_INTERACTION_FREQUENCY = 20;
 
     string internal constant ERROR_VALUE = "Invalid value";
     string internal constant ERROR_ADDRESS = "Invalid address";
@@ -514,14 +501,6 @@ contract StateUtils is IStateUtils {
         }
         else
         {
-            if (checkpointArray.length + 1 >= MAX_INTERACTION_FREQUENCY)
-            {
-                uint256 interactionTimestampMaxInteractionFrequencyAgo = snapshotBlockToTimestamp[checkpointArray[checkpointArray.length + 1 - MAX_INTERACTION_FREQUENCY].fromBlock];
-                require(
-                    block.timestamp - interactionTimestampMaxInteractionFrequencyAgo > EPOCH_LENGTH,
-                    ERROR_FREQUENCY
-                    );
-            }
             Checkpoint storage lastElement = checkpointArray[checkpointArray.length - 1];
             if (lastElement.fromBlock < lastVoteSnapshotBlock)
             {

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting;
-let EPOCH_LENGTH, MAX_INTERACTION_FREQUENCY;
+let EPOCH_LENGTH;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -44,7 +44,6 @@ beforeEach(async () => {
       roles.votingAppSecondary.address
     );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
-  MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
 const user1Stake = ethers.utils.parseEther(
@@ -91,9 +90,8 @@ describe("delegateVotingPower", function () {
           "User has not updated their delegation status less than reward epoch ago",
           function () {
             context("User did not have the same delegate", function () {
-              context(
-                "Receiving user has not been delegated to too frequently",
-                function () {
+
+
                   it("delegates voting power", async function () {
                     // Have user 1 delegate to someone else first
                     await api3Pool
@@ -130,76 +128,7 @@ describe("delegateVotingPower", function () {
                       await api3Pool.userDelegate(roles.user1.address)
                     ).to.equal(roles.user2.address);
                   });
-                }
-              );
-              context(
-                "Receiving user has been delegated to too frequently",
-                function () {
-                  it("reverts", async function () {
-                    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-                      const randomWallet = ethers.Wallet.createRandom().connect(
-                        ethers.provider
-                      );
-                      await roles.deployer.sendTransaction({
-                        to: randomWallet.address,
-                        value: ethers.utils.parseEther("1"),
-                      });
-                      const amount = ethers.BigNumber.from("10000000000000000");
-                      await api3Token
-                        .connect(roles.deployer)
-                        .transfer(randomWallet.address, amount);
-                      await api3Token
-                        .connect(randomWallet)
-                        .approve(api3Pool.address, amount, {
-                          gasLimit: 500000,
-                        });
-                      await api3Pool
-                        .connect(randomWallet)
-                        .depositAndStake(
-                          randomWallet.address,
-                          amount,
-                          randomWallet.address,
-                          { gasLimit: 500000 }
-                        );
-                      await api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        });
-                      await api3Voting.newVote();
-                    }
-                    const randomWallet = ethers.Wallet.createRandom().connect(
-                      ethers.provider
-                    );
-                    await roles.deployer.sendTransaction({
-                      to: randomWallet.address,
-                      value: ethers.utils.parseEther("1"),
-                    });
-                    const amount = ethers.BigNumber.from("10000000000000000");
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(randomWallet.address, amount);
-                    await api3Token
-                      .connect(randomWallet)
-                      .approve(api3Pool.address, amount, { gasLimit: 500000 });
-                    await api3Pool
-                      .connect(randomWallet)
-                      .depositAndStake(
-                        randomWallet.address,
-                        amount,
-                        randomWallet.address,
-                        { gasLimit: 500000 }
-                      );
-                    await expect(
-                      api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        })
-                    ).to.be.revertedWith("Try again a week later");
-                  });
-                }
-              );
+                  
             });
             context("User had the same delegate", function () {
               it("reverts", async function () {

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -43,10 +43,6 @@ describe("constructor", function () {
     expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
       ethers.BigNumber.from(52)
     );
-    // Max interaction frequency is 20
-    expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
-      ethers.BigNumber.from(20)
-    );
 
     // App addresses are not set
     expect(await api3Pool.agentAppPrimary()).to.equal(


### PR DESCRIPTION
Addresses the "Token holders with 2% of the tokens can block any user from being delegated to" issue. Instead of linearly searching `MAX_INTERACTION_FREQUENCY` to get the voting power delegated power to a user, the value is first attempted to be found among the last 5 elements. If that fails, binary search is applied to the last 1000 elements (100% / 0.1% minimum `proposalVotingPowerThreshold` = 1000).