### PR TITLE
Prevent payout avoidance

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -254,7 +254,7 @@ contract Api3Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
-        (, , , , uint256 mostRecentProposalTimestamp, , , uint256 mostRecentUndelegationTimestamp) = api3Pool.getUser(msg.sender);
+        (, , , , , uint256 mostRecentProposalTimestamp, , , uint256 mostRecentUndelegationTimestamp) = api3Pool.getUser(msg.sender);
         require(mostRecentProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         require(mostRecentUndelegationTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_UNDELEGATION_COOLDOWN");
         api3Pool.updateMostRecentProposalTimestamp(msg.sender);
@@ -294,7 +294,7 @@ contract Api3Voting is IForwarder, AragonApp {
         bool _executesIfDecided
     ) internal
     {
-        (, , , , , , , uint256 mostRecentUndelegationTimestamp) = api3Pool.getUser(msg.sender);
+        (, , , , , , , , uint256 mostRecentUndelegationTimestamp) = api3Pool.getUser(msg.sender);
         require(mostRecentUndelegationTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_UNDELEGATION_COOLDOWN");
         api3Pool.updateMostRecentVoteTimestamp(msg.sender);
         Vote storage vote_ = votes[_voteId];

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -84,8 +84,9 @@ contract Api3TokenMock is MiniMeToken {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
+            uint256 unstakeScheduledFor,
             uint256 mostRecentProposalTimestamp,
             uint256 mostRecentVoteTimestamp,
             uint256 mostRecentDelegationTimestamp,
@@ -94,8 +95,9 @@ contract Api3TokenMock is MiniMeToken {
     {
         unstaked = 0;
         vesting = 0;
-        unstakeScheduledFor = 0;
+        unstakeShares = 0;
         unstakeAmount = 0;
+        unstakeScheduledFor = 0;
         mostRecentProposalTimestamp = 0;
         mostRecentVoteTimestamp = 0;
         mostRecentDelegationTimestamp = 0;

--- a/packages/dao/package.json
+++ b/packages/dao/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prepublishOnly": "npm run compile && npm run abi:extract -- --no-compile",
     "abi:extract": "truffle-extract --output abi/ --keys abi",
-    "compile": "truffle compile --all",
+    "compile": "node --stack-size=4096 node_modules/.bin/truffle compile --all",
+    "compile:original": "truffle compile --all",
     "lint": "solium --dir ./contracts",
     "test": "npm run prepublishOnly && cd ../pool && npm run build && cp ./artifacts/contracts/Api3Pool.sol/Api3Pool.json ../dao/build/contracts/Api3Pool.json && cd ../dao  && npm run test:ganache",
     "test:ganache": "./node_modules/@aragon/templates-shared/scripts/test-ganache.sh",

--- a/packages/pool/contracts/Api3Pool.sol
+++ b/packages/pool/contracts/Api3Pool.sol
@@ -6,11 +6,11 @@ import "./interfaces/IApi3Pool.sol";
 
 /// @title API3 pool contract
 /// @notice Users can stake API3 tokens at the pool contract to be granted
-/// shares. These shares are exposed to the Aragon-based DAO with a MiniMe
-/// token interface, giving the user voting power at the DAO. Staking pays out
-/// weekly rewards that get unlocked after a year, and staked funds are used to
-/// collateralize an insurance product that is outside the scope of this
-/// contract.
+/// shares. These shares are exposed to the Aragon-based DAO with a
+/// pseudo-MiniMe token interface, giving the user voting power at the DAO.
+/// Staking pays out weekly rewards that get unlocked after a year, and staked
+/// funds are used to collateralize an insurance product that is outside the
+/// scope of this contract.
 /// @dev Functionalities of the contract are distributed to files that form a
 /// chain of inheritance:
 /// (1) Api3Pool.sol

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -106,16 +106,19 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
     /// the delegated voting power
     /// @dev User shares only get updated while staking, scheduling unstake
     /// or unstaking
+    /// @param userAddress Address of the user whose delegated voting power
+    /// will be updated
     /// @param shares Amount of shares that will be added/removed
     /// @param delta Whether the shares will be added/removed (add for `true`,
     /// and vice versa)
     function updateDelegatedVotingPower(
+        address userAddress,
         uint256 shares,
         bool delta
         )
         internal
     {
-        address userDelegate = userDelegate(msg.sender);
+        address userDelegate = userDelegate(userAddress);
         if (userDelegate == address(0)) {
             return;
         }

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -277,6 +277,21 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         }
     }
 
+    /// @notice Called to get the details of a user
+    /// @param userAddress User address
+    /// @return unstaked Amount of unstaked API3 tokens
+    /// @return vesting Amount of API3 tokens locked by vesting
+    /// @return unstakeShares Shares scheduled to unstake
+    /// @return unstakeAmount Amount scheduled to unstake
+    /// @return unstakeScheduledFor Time unstaking is scheduled for
+    /// @return mostRecentProposalTimestamp Time when the user made their most
+    /// recent proposal
+    /// @return mostRecentVoteTimestamp Time when the user cast their most
+    /// recent vote
+    /// @return mostRecentDelegationTimestamp Time when the user made their
+    /// most recent delegation
+    /// @return mostRecentUndelegationTimestamp Time when the user made their
+    /// most recent undelegation
     function getUser(address userAddress)
         external
         view

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -284,8 +284,9 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
+            uint256 unstakeScheduledFor,
             uint256 mostRecentProposalTimestamp,
             uint256 mostRecentVoteTimestamp,
             uint256 mostRecentDelegationTimestamp,
@@ -295,8 +296,9 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         User storage user = users[userAddress];
         unstaked = user.unstaked;
         vesting = user.vesting;
-        unstakeScheduledFor = user.unstakeScheduledFor;
+        unstakeShares = user.unstakeShares;
         unstakeAmount = user.unstakeAmount;
+        unstakeScheduledFor = user.unstakeScheduledFor;
         mostRecentProposalTimestamp = user.mostRecentProposalTimestamp;
         mostRecentVoteTimestamp = user.mostRecentVoteTimestamp;
         mostRecentDelegationTimestamp = user.mostRecentDelegationTimestamp;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -28,8 +28,9 @@ contract StateUtils is IStateUtils {
         Checkpoint[] delegatedTo;
         uint256 unstaked;
         uint256 vesting;
-        uint256 unstakeScheduledFor;
+        uint256 unstakeShares;
         uint256 unstakeAmount;
+        uint256 unstakeScheduledFor;
         uint256 mostRecentProposalTimestamp;
         uint256 mostRecentVoteTimestamp;
         uint256 mostRecentDelegationTimestamp;

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -90,8 +90,9 @@ interface IGetterUtils is IStateUtils {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
+            uint256 unstakeScheduledFor,
             uint256 mostRecentProposalTimestamp,
             uint256 mostRecentVoteTimestamp,
             uint256 mostRecentDelegationTimestamp,

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -12,14 +12,14 @@ interface IStakeUtils is ITransferUtils{
 
     event ScheduledUnstake(
         address indexed user,
+        uint256 shares,
         uint256 amount,
         uint256 scheduledFor
         );
 
     event Unstaked(
         address indexed user,
-        uint256 amount,
-        uint256 totalShares
+        uint256 amount
         );
 
     function stake(uint256 amount)
@@ -32,7 +32,7 @@ interface IStakeUtils is ITransferUtils{
         )
         external;
 
-    function scheduleUnstake(uint256 amount)
+    function scheduleUnstake(uint256 shares)
         external;
 
     function unstake(address userAddress)

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -35,7 +35,7 @@ interface IStakeUtils is ITransferUtils{
     function scheduleUnstake(uint256 amount)
         external;
 
-    function unstake()
+    function unstake(address userAddress)
         external
         returns(uint256);
 

--- a/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
+++ b/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
@@ -42,8 +42,9 @@ interface IApi3Pool {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
+            uint256 unstakeScheduledFor,
             uint256 mostRecentProposalTimestamp,
             uint256 mostRecentVoteTimestamp,
             uint256 mostRecentDelegationTimestamp,

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -47,12 +47,8 @@ beforeEach(async () => {
   MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
-const user1Stake = ethers.utils.parseEther(
-  "20" + "000" + "000"
-);
-const user2Stake = ethers.utils.parseEther(
-  "60" + "000" + "000"
-);
+const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
+const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
 
 describe("delegateVotingPower", function () {
   beforeEach(async () => {
@@ -63,26 +59,14 @@ describe("delegateVotingPower", function () {
     await api3Token
       .connect(roles.deployer)
       .transfer(roles.user2.address, user2Stake);
-    await api3Token
-      .connect(roles.user1)
-      .approve(api3Pool.address, user1Stake);
-    await api3Token
-      .connect(roles.user2)
-      .approve(api3Pool.address, user2Stake);
+    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
+    await api3Token.connect(roles.user2).approve(api3Pool.address, user2Stake);
     await api3Pool
       .connect(roles.user1)
-      .depositAndStake(
-        roles.user1.address,
-        user1Stake,
-        roles.user1.address
-      );
+      .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
     await api3Pool
       .connect(roles.user2)
-      .depositAndStake(
-        roles.user2.address,
-        user2Stake,
-        roles.user2.address
-      );
+      .depositAndStake(roles.user2.address, user2Stake, roles.user2.address);
   });
   context("Delegate address is not zero", function () {
     context("Delegate address is not caller", function () {
@@ -248,7 +232,6 @@ describe("delegateVotingPower", function () {
       });
       context("Delegate is delegating", function () {
         it("reverts", async function () {
-
           // Have user 2 delegate to someone else first
           await api3Pool
             .connect(roles.user2)
@@ -290,26 +273,14 @@ describe("undelegateVotingPower", function () {
     await api3Token
       .connect(roles.deployer)
       .transfer(roles.user2.address, user2Stake);
-    await api3Token
-      .connect(roles.user1)
-      .approve(api3Pool.address, user1Stake);
-    await api3Token
-      .connect(roles.user2)
-      .approve(api3Pool.address, user2Stake);
+    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
+    await api3Token.connect(roles.user2).approve(api3Pool.address, user2Stake);
     await api3Pool
       .connect(roles.user1)
-      .depositAndStake(
-        roles.user1.address,
-        user1Stake,
-        roles.user1.address
-      );
+      .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
     await api3Pool
       .connect(roles.user2)
-      .depositAndStake(
-        roles.user2.address,
-        user2Stake,
-        roles.user2.address
-      );
+      .depositAndStake(roles.user2.address, user2Stake, roles.user2.address);
   });
   context("User has delegated before", function () {
     context(

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -153,7 +153,9 @@ describe("userReceivedDelegationAt", function () {
   context("Searched block is within MAX_INTERACTION_FREQUENCY", function () {
     it("gets user's received delegation at the block", async function () {
       const genesisEpoch = await api3Pool.genesisEpoch();
-      const amount = ethers.BigNumber.from("10" + "000" + "000" + "000" + "000" + "000");
+      const amount = ethers.BigNumber.from(
+        "10" + "000" + "000" + "000" + "000" + "000"
+      );
       const delegationBlocks = [];
       for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
         await api3Voting.newVote();
@@ -198,7 +200,9 @@ describe("userReceivedDelegationAt", function () {
     function () {
       it("reverts", async function () {
         const genesisEpoch = await api3Pool.genesisEpoch();
-        const amount = ethers.BigNumber.from("10" + "000" + "000" + "000" + "000" + "000");
+        const amount = ethers.BigNumber.from(
+          "10" + "000" + "000" + "000" + "000" + "000"
+        );
         const delegationBlocks = [];
         for (
           let i = 0;
@@ -260,7 +264,9 @@ describe("userReceivedDelegationAt", function () {
 
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
-    const amount = ethers.BigNumber.from("10" + "000" + "000" + "000" + "000" + "000");
+    const amount = ethers.BigNumber.from(
+      "10" + "000" + "000" + "000" + "000" + "000"
+    );
     await api3Token
       .connect(roles.deployer)
       .transfer(roles.user1.address, amount);
@@ -269,12 +275,9 @@ describe("getDelegateAt", function () {
       .approve(api3Pool.address, amount, { gasLimit: 500000 });
     await api3Pool
       .connect(roles.user1)
-      .depositAndStake(
-        roles.user1.address,
-        amount,
-        roles.user1.address,
-        { gasLimit: 500000 }
-      );
+      .depositAndStake(roles.user1.address, amount, roles.user1.address, {
+        gasLimit: 500000,
+      });
 
     const firstBlockNumber = await ethers.provider.getBlockNumber();
     await api3Pool

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -174,6 +174,7 @@ describe("scheduleUnstake", function () {
       await api3Pool
         .connect(roles.user1)
         .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+      const userShares = await api3Pool.userShares(roles.user1.address);
       const currentBlock = await ethers.provider.getBlock(
         await ethers.provider.getBlockNumber()
       );
@@ -183,7 +184,12 @@ describe("scheduleUnstake", function () {
       // Schedule unstake
       await expect(api3Pool.connect(roles.user1).scheduleUnstake(user1Stake))
         .to.emit(api3Pool, "ScheduledUnstake")
-        .withArgs(roles.user1.address, user1Stake, unstakeScheduledFor);
+        .withArgs(
+          roles.user1.address,
+          user1Stake,
+          userShares,
+          unstakeScheduledFor
+        );
     });
   });
   context("User does not have enough staked to schedule unstake", function () {
@@ -197,121 +203,67 @@ describe("scheduleUnstake", function () {
 
 describe("unstake", function () {
   context("Enough time has passed since the unstake scheduling", function () {
-    context("The unstake has not expired", function () {
-      context("User still has the tokens to unstake", function () {
-        context("User has a delegate", function () {
-          it("unstakes and updates delegated voting power", async function () {
-            // Authorize pool contract to mint tokens
-            await api3Token
-              .connect(roles.deployer)
-              .updateMinterStatus(api3Pool.address, true);
-            // Have the user stake
-            const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user1.address, user1Stake);
-            await api3Token
-              .connect(roles.user1)
-              .approve(api3Pool.address, user1Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            // Have the user delegate
-            await api3Pool
-              .connect(roles.user1)
-              .delegateVotingPower(roles.user2.address);
-            expect(
-              await api3Pool.userReceivedDelegation(roles.user2.address)
-            ).to.equal(ethers.BigNumber.from(user1Stake));
-            expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
-              roles.user2.address
+    context("User still has the tokens to unstake", function () {
+      context("User has a delegate", function () {
+        it("unstakes and updates delegated voting power", async function () {
+          // Authorize pool contract to mint tokens
+          await api3Token
+            .connect(roles.deployer)
+            .updateMinterStatus(api3Pool.address, true);
+          // Have the user stake
+          const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
+          await api3Token
+            .connect(roles.deployer)
+            .transfer(roles.user1.address, user1Stake);
+          await api3Token
+            .connect(roles.user1)
+            .approve(api3Pool.address, user1Stake);
+          await api3Pool
+            .connect(roles.user1)
+            .depositAndStake(
+              roles.user1.address,
+              user1Stake,
+              roles.user1.address
             );
-            // Schedule unstake
-            await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
-            // Fast forward time to one epoch into the future
-            const genesisEpoch = await api3Pool.genesisEpoch();
-            const genesisEpochPlusTwo = genesisEpoch.add(
-              ethers.BigNumber.from(2)
-            );
-            await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
-            ]);
-            // Unstake
-            await api3Pool.payReward();
-            const totalStakeNow = await api3Pool.totalStake();
-            const totalStakeAfter = totalStakeNow.sub(user1Stake);
-            const expectedTotalShares = totalStakeAfter
-              .mul(user1Stake)
-              .div(totalStakeNow)
-              .add(ethers.BigNumber.from(1));
-            await expect(api3Pool.unstake(roles.user1.address))
-              .to.emit(api3Pool, "Unstaked")
-              .withArgs(roles.user1.address, user1Stake, expectedTotalShares);
-            // Delegation remains
-            expect(
-              await api3Pool.userReceivedDelegation(roles.user2.address)
-            ).to.equal(await api3Pool.userShares(roles.user1.address));
-            // This epoch's reward remains as being delegated
-            /*expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
-              roles.user2.address
-            );
-            const user = await api3Pool.users(roles.user1.address);
-            expect(user.unstaked).to.equal(user1Stake);*/
-          });
-        });
-        context("User does not have a delegate", function () {
-          it("unstakes", async function () {
-            // Authorize pool contract to mint tokens
-            await api3Token
-              .connect(roles.deployer)
-              .updateMinterStatus(api3Pool.address, true);
-            // Have the user stake
-            const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-            await api3Token
-              .connect(roles.deployer)
-              .transfer(roles.user1.address, user1Stake);
-            await api3Token
-              .connect(roles.user1)
-              .approve(api3Pool.address, user1Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            // Schedule unstake
-            await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
-            // Fast forward time to one epoch into the future
-            const genesisEpoch = await api3Pool.genesisEpoch();
-            const genesisEpochPlusTwo = genesisEpoch.add(
-              ethers.BigNumber.from(2)
-            );
-            await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
-            ]);
-            // Unstake
-            await api3Pool.payReward();
-            const totalStakeNow = await api3Pool.totalStake();
-            const totalStakeAfter = totalStakeNow.sub(user1Stake);
-            const expectedTotalShares = totalStakeAfter
-              .mul(user1Stake)
-              .div(totalStakeNow)
-              .add(ethers.BigNumber.from(1));
-            await expect(api3Pool.unstake(roles.user1.address))
-              .to.emit(api3Pool, "Unstaked")
-              .withArgs(roles.user1.address, user1Stake, expectedTotalShares);
-            const user = await api3Pool.users(roles.user1.address);
-            expect(user.unstaked).to.equal(user1Stake);
-          });
+          // Have the user delegate
+          await api3Pool
+            .connect(roles.user1)
+            .delegateVotingPower(roles.user2.address);
+          expect(
+            await api3Pool.userReceivedDelegation(roles.user2.address)
+          ).to.equal(ethers.BigNumber.from(user1Stake));
+          expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
+            roles.user2.address
+          );
+          // Schedule unstake
+          await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
+          // Fast forward time to one epoch into the future
+          const genesisEpoch = await api3Pool.genesisEpoch();
+          const genesisEpochPlusTwo = genesisEpoch.add(
+            ethers.BigNumber.from(2)
+          );
+          await ethers.provider.send("evm_setNextBlockTimestamp", [
+            genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
+          ]);
+          // Unstake
+          await api3Pool.payReward();
+          await expect(api3Pool.unstake(roles.user1.address))
+            .to.emit(api3Pool, "Unstaked")
+            .withArgs(roles.user1.address, user1Stake);
+          // Delegation remains
+          expect(
+            await api3Pool.userReceivedDelegation(roles.user2.address)
+          ).to.equal(await api3Pool.userShares(roles.user1.address));
+          // This epoch's reward remains as being delegated
+          expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
+            roles.user2.address
+          );
+          const user = await api3Pool.users(roles.user1.address);
+          expect(user.unstaked).to.equal(user1Stake);
         });
       });
-      context("User no longer has the tokens to unstake", function () {
-        it("unstakes as much as possible", async function () {
+      context("User does not have a delegate", function () {
+        it("unstakes", async function () {
           // Authorize pool contract to mint tokens
           await api3Token
             .connect(roles.deployer)
@@ -333,28 +285,6 @@ describe("unstake", function () {
             );
           // Schedule unstake
           await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
-          // Set the DAO Agent
-          await api3Pool
-            .connect(roles.randomPerson)
-            .setDaoApps(
-              roles.agentAppPrimary.address,
-              roles.agentAppSecondary.address,
-              roles.votingAppPrimary.address,
-              roles.votingAppSecondary.address
-            );
-          // Set claims manager status as true with the DAO Agent
-          await api3Pool
-            .connect(roles.agentAppPrimary)
-            .setClaimsManagerStatus(roles.claimsManager.address, true);
-          // Pay out the entire pool for a claim
-          await api3Pool
-            .connect(roles.claimsManager)
-            .payOutClaim(
-              roles.claimsManager.address,
-              (await api3Token.balanceOf(api3Pool.address)).sub(
-                ethers.BigNumber.from(1)
-              )
-            );
           // Fast forward time to one epoch into the future
           const genesisEpoch = await api3Pool.genesisEpoch();
           const genesisEpochPlusTwo = genesisEpoch.add(
@@ -364,27 +294,17 @@ describe("unstake", function () {
             genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
           ]);
           // Unstake
-          const userStakedBeforeUnstake = await api3Pool.userStake(
-            roles.user1.address
-          );
+          await api3Pool.payReward();
           await expect(api3Pool.unstake(roles.user1.address))
             .to.emit(api3Pool, "Unstaked")
-            .withArgs(
-              roles.user1.address,
-              userStakedBeforeUnstake,
-              ethers.BigNumber.from(1)
-            );
-          const userStakedAfterUnstake = await api3Pool.userStake(
-            roles.user1.address
-          );
+            .withArgs(roles.user1.address, user1Stake);
           const user = await api3Pool.users(roles.user1.address);
-          expect(user.unstaked).to.equal(userStakedBeforeUnstake);
-          expect(userStakedAfterUnstake).to.equal(ethers.BigNumber.from(0));
+          expect(user.unstaked).to.equal(user1Stake);
         });
       });
     });
-    context("The unstake has expired", function () {
-      it("reverts", async function () {
+    context("User no longer has the tokens to unstake", function () {
+      it("unstakes as much as possible", async function () {
         // Authorize pool contract to mint tokens
         await api3Token
           .connect(roles.deployer)
@@ -406,16 +326,44 @@ describe("unstake", function () {
           );
         // Schedule unstake
         await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
+        // Set the DAO Agent
+        await api3Pool
+          .connect(roles.randomPerson)
+          .setDaoApps(
+            roles.agentAppPrimary.address,
+            roles.agentAppSecondary.address,
+            roles.votingAppPrimary.address,
+            roles.votingAppSecondary.address
+          );
+        // Set claims manager status as true with the DAO Agent
+        await api3Pool
+          .connect(roles.agentAppPrimary)
+          .setClaimsManagerStatus(roles.claimsManager.address, true);
+        // Pay out the entire pool for a claim
+        await api3Pool
+          .connect(roles.claimsManager)
+          .payOutClaim(
+            roles.claimsManager.address,
+            (await api3Token.balanceOf(api3Pool.address)).sub(
+              ethers.BigNumber.from(1)
+            )
+          );
         // Fast forward time to one epoch into the future
         const genesisEpoch = await api3Pool.genesisEpoch();
-        const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
+        const genesisEpochPlusTwo = genesisEpoch.add(ethers.BigNumber.from(2));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
+          genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
         ]);
-        // Attempt to unstake
-        await expect(
-          api3Pool.unstake(roles.user1.address)
-        ).to.be.revertedWith("Unauthorized");
+        // Unstake
+        await expect(api3Pool.unstake(roles.user1.address))
+          .to.emit(api3Pool, "Unstaked")
+          .withArgs(roles.user1.address, 1);
+        const userStakedAfterUnstake = await api3Pool.userStake(
+          roles.user1.address
+        );
+        const user = await api3Pool.users(roles.user1.address);
+        expect(user.unstaked).to.equal(1);
+        expect(userStakedAfterUnstake).to.equal(ethers.BigNumber.from(0));
       });
     });
   });
@@ -445,9 +393,9 @@ describe("unstake", function () {
         // Schedule unstake
         await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
         // Attempt to unstake
-        await expect(
-          api3Pool.unstake(roles.user1.address)
-        ).to.be.revertedWith("Unauthorized");
+        await expect(api3Pool.unstake(roles.user1.address)).to.be.revertedWith(
+          "Unauthorized"
+        );
       });
     }
   );

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -248,7 +248,7 @@ describe("unstake", function () {
               .mul(user1Stake)
               .div(totalStakeNow)
               .add(ethers.BigNumber.from(1));
-            await expect(api3Pool.connect(roles.user1).unstake())
+            await expect(api3Pool.unstake(roles.user1.address))
               .to.emit(api3Pool, "Unstaked")
               .withArgs(roles.user1.address, user1Stake, expectedTotalShares);
             // Delegation remains
@@ -256,11 +256,11 @@ describe("unstake", function () {
               await api3Pool.userReceivedDelegation(roles.user2.address)
             ).to.equal(await api3Pool.userShares(roles.user1.address));
             // This epoch's reward remains as being delegated
-            expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
+            /*expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
               roles.user2.address
             );
             const user = await api3Pool.users(roles.user1.address);
-            expect(user.unstaked).to.equal(user1Stake);
+            expect(user.unstaked).to.equal(user1Stake);*/
           });
         });
         context("User does not have a delegate", function () {
@@ -302,7 +302,7 @@ describe("unstake", function () {
               .mul(user1Stake)
               .div(totalStakeNow)
               .add(ethers.BigNumber.from(1));
-            await expect(api3Pool.connect(roles.user1).unstake())
+            await expect(api3Pool.unstake(roles.user1.address))
               .to.emit(api3Pool, "Unstaked")
               .withArgs(roles.user1.address, user1Stake, expectedTotalShares);
             const user = await api3Pool.users(roles.user1.address);
@@ -367,7 +367,7 @@ describe("unstake", function () {
           const userStakedBeforeUnstake = await api3Pool.userStake(
             roles.user1.address
           );
-          await expect(api3Pool.connect(roles.user1).unstake())
+          await expect(api3Pool.unstake(roles.user1.address))
             .to.emit(api3Pool, "Unstaked")
             .withArgs(
               roles.user1.address,
@@ -414,7 +414,7 @@ describe("unstake", function () {
         ]);
         // Attempt to unstake
         await expect(
-          api3Pool.connect(roles.user1).unstake()
+          api3Pool.unstake(roles.user1.address)
         ).to.be.revertedWith("Unauthorized");
       });
     });
@@ -446,7 +446,7 @@ describe("unstake", function () {
         await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
         // Attempt to unstake
         await expect(
-          api3Pool.connect(roles.user1).unstake()
+          api3Pool.unstake(roles.user1.address)
         ).to.be.revertedWith("Unauthorized");
       });
     }

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -81,7 +81,7 @@ describe("withdraw", function () {
       // Schedule unstake and execute
       await api3Pool
         .connect(roles.user1)
-        .scheduleUnstake(await api3Pool.userStake(roles.user1.address));
+        .scheduleUnstake(await api3Pool.userShares(roles.user1.address));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
         genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
       ]);

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -85,7 +85,7 @@ describe("withdraw", function () {
       await ethers.provider.send("evm_setNextBlockTimestamp", [
         genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
       ]);
-      await api3Pool.connect(roles.user1).unstake();
+      await api3Pool.unstake(roles.user1.address);
       const userBefore = await api3Pool.users(roles.user1.address);
       const unlocked = userBefore.unstaked.sub(
         await api3Pool.callStatic.getUserLocked(roles.user1.address)


### PR DESCRIPTION
User shares get deducted while scheduling the unstake, and they get deducted from the total supply while unstaking.
The tokens scheduled to be unstaked don't receive any rewards/count towards voting power, but get hit by claim payouts.
Scheduled unstakings no longer "timeout", if you scheduled an unstaking, you will have to execute it before scheduling a new one.
Anyone can execute a matured scheduled unstaking.
One awkward thing about the implementation is that if the user gets hit by a claim payout before unstaking execution, they will receive rewards. For example the user scheduled an unstaking for 5000 tokens, then a claim payout slashes the pool by 20%. At the time the unstaking has matured, the amount that the user can unstake will be `min(5000, 4000 + 4000's rewards)` so something like 4050. This is tolerated because it can't be prevented in a gas-efficient way and the main point was to prevent users from abusing schedulings and this is largely achieved.