### PR TITLE
[QSP-3] Replace linear searches with binary searches

### DIFF
--- a/packages/api3-voting/test/delegation-integration.js
+++ b/packages/api3-voting/test/delegation-integration.js
@@ -14,7 +14,7 @@ const VOTER_STATE = ['ABSENT', 'YEA', 'NAY'].reduce((state, key, index) => {
     state[key] = index;
     return state;
 }, {});
-
+const MOCK_TIMELOCKMANAGER_ADDRESS = "0x0000000000000000000000000000000000000001";
 
 contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, nonVoter]) => {
     let pool, votingBase, voting, token, executionTarget;
@@ -29,7 +29,7 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
         token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true);
 
         votingBase = await Voting.new();
-        pool = await Api3Pool.new(token.address);
+        pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
 
         // ROLES are below
         CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE();
@@ -59,13 +59,13 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
             await token.generateTokens(voter3, balance3);
 
             await token.approve(pool.address, balance1, {from:voter1});
-            await pool.depositAndStake(voter1, balance1, voter1, {from:voter1});
+            await pool.depositAndStake(balance1, {from:voter1});
 
             await token.approve(pool.address, balance2, {from:voter2});
-            await pool.depositAndStake(voter2, balance2, voter2, {from:voter2});
+            await pool.depositAndStake(balance2, {from:voter2});
 
             await token.approve(pool.address, balance3, {from:voter3});
-            await pool.depositAndStake(voter3, balance3, voter3, {from:voter3});
+            await pool.depositAndStake(balance3, {from:voter3});
 
             await pool.setDaoApps(voting.address, voting.address, voting.address, voting.address);
         });

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -15,6 +15,7 @@ const VOTER_STATE = ['ABSENT', 'YEA', 'NAY'].reduce((state, key, index) => {
   state[key] = index;
   return state;
 }, {});
+const MOCK_TIMELOCKMANAGER_ADDRESS = "0x0000000000000000000000000000000000000001";
 
 
 contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder51, nonHolder]) => {
@@ -47,7 +48,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
 
     beforeEach(async () => {
       token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true); // empty parameters minime
-      api3Pool = await Api3Pool.new(token.address);
+      api3Pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
       await api3Pool.setDaoApps(voting.address, voting.address, voting.address, voting.address);
 
       await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration);
@@ -106,7 +107,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
 
       beforeEach(async () => {
         token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', decimals, 'n', true); // empty parameters minime
-        api3Pool = await Api3Pool.new(token.address);
+        api3Pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
         await api3Pool.setDaoApps(voting.address, voting.address, voting.address, voting.address);
 
         await token.generateTokens(holder20, bigExp(20, decimals));
@@ -117,15 +118,15 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
 
         // holder 51 deposit and stake
         await token.approve(api3Pool.address, bigExp(51, decimals), {from:holder51});
-        await api3Pool.depositAndStake(holder51, bigExp(51, decimals), holder51, {from:holder51});
+        await api3Pool.depositAndStake(bigExp(51, decimals), {from:holder51});
 
         // holder 29
         await token.approve(api3Pool.address, bigExp(29, decimals), {from:holder29});
-        await api3Pool.depositAndStake(holder29, bigExp(29, decimals), holder29, {from:holder29});
+        await api3Pool.depositAndStake(bigExp(29, decimals), {from:holder29});
 
         // holder 20
         await token.approve(api3Pool.address, bigExp(20, decimals), {from:holder20});
-        await api3Pool.depositAndStake(holder20, bigExp(20, decimals), holder20, {from:holder20});
+        await api3Pool.depositAndStake(bigExp(20, decimals), {from:holder20});
 
         executionTarget = await ExecutionTarget.new()
       });

--- a/packages/dao/test/api3template.js
+++ b/packages/dao/test/api3template.js
@@ -15,6 +15,8 @@ const Api3Template = artifacts.require('Api3Template');
 const Api3Pool = artifacts.require('Api3Pool');
 const Agent = artifacts.require('Agent');
 
+const MOCK_TIMELOCKMANAGER_ADDRESS = "0x0000000000000000000000000000000000000001";
+
 contract('Api3Template', ([_, deployer, tokenAddress, authorized]) => { // eslint-disable-line no-unused-vars
   let api3Template, dao, acl, receipt1, api3Pool;
 
@@ -32,7 +34,7 @@ contract('Api3Template', ([_, deployer, tokenAddress, authorized]) => { // eslin
   });
 
   before('create bare entity', async () => {
-    api3Pool = await Api3Pool.new(tokenAddress);
+    api3Pool = await Api3Pool.new(tokenAddress, MOCK_TIMELOCKMANAGER_ADDRESS);
     receipt1 = await api3Template.newInstance('api3template', (api3Pool.address), [SUPPORT_1, ACCEPTANCE_1, VOTING_DURATION_1], [SUPPORT_2, ACCEPTANCE_2, VOTING_DURATION_2], { from: deployer });
 
     dao = Kernel.at(getEventArgument(receipt1, 'DeployDao', 'dao'));

--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -113,15 +113,6 @@ This array will be searched linearly while calling `balanceOfAt()` to vote (for 
 In case the user bloats this array on purpose by repeatedly staking 1 (Wei) API3, they may manage to lock themselves out of voting/withdrawing.
 Since this will only happen voluntarily and will get resolved automatically simply by not staking/unstaking for a while, it is not considered as an issue.
 
-## Over-population of `user.delegatedTo` and the interaction frequency limit
-
-Each time a user is delegated to/undelegated from, their `user.delegatedTo` will be updated.
-Furthermore, if there has been a proposal made since the last update, a new element will be added to the `Checkpoint` array.
-This array will be searched linearly when the delegated user calls `balanceOfAt()` to vote (for the last week).
-A concern here is that too many interleaved proposals and delegation updates may bloat the user's `delegatedTo` array for the last week and prevent them from voting.
-To prevent this from being used as an attack vector, a transaction cannot add more than `MAX_INTERACTION_FREQUENCY` (default value = `20`) elements to a user's `delegatedTo` in a week.
-The proposal spam protection mechanisms are expected to keep the number of proposals in a week well below `20` (and if they cannot, their parameters should be updated to reduce spam further).
-
 ## Double Agent and Api3Voting apps
 
 The DAO will have two pairs of Agents and Api3Voting apps, where having an Agent app make a transaction will require a proposal to be passed with the respective Api3Voting app.

--- a/packages/pool/contracts/Api3Pool.sol
+++ b/packages/pool/contracts/Api3Pool.sol
@@ -24,7 +24,13 @@ import "./interfaces/IApi3Pool.sol";
 /// (9) StateUtils.sol
 contract Api3Pool is TimelockUtils, IApi3Pool {
     /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
-        StateUtils(api3TokenAddress)
+    constructor(
+        address api3TokenAddress,
+        address timelockManagerAddress
+        )
+        StateUtils(
+            api3TokenAddress,
+            timelockManagerAddress
+            )
     {}
 }

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -49,10 +49,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             userReceivedDelegation(delegate) + userShares
             );
         // Record the new delegate for the user
-        updateAddressCheckpointArray(
-            user.delegates,
-            delegate
-            );
+        user.delegates.push(AddressCheckpoint({
+            fromBlock: block.number,
+            _address: delegate
+            }));
         emit Delegated(
             msg.sender,
             delegate
@@ -79,10 +79,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             delegate.delegatedTo,
             userReceivedDelegation(userDelegate) - userShares
             );
-        updateAddressCheckpointArray(
-            user.delegates,
-            address(0)
-            );
+        user.delegates.push(AddressCheckpoint({
+            fromBlock: block.number,
+            _address: address(0)
+            }));
         user.lastDelegationUpdateTimestamp = block.timestamp;
         emit Undelegated(
             msg.sender,

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -227,7 +227,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         Checkpoint[] storage checkpoints,
         uint256 _block
         )
-        private
+        internal
         view
         returns(uint256)
     {

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -72,8 +72,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the pool shares of a user at a specific block
-    /// @dev Starts from the most recent value in `user.shares` and searches
-    /// backwards one element at a time
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Pool shares of the user at the block
@@ -86,7 +84,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        return getValueAt(users[userAddress].shares, _block, 0);
+        return getValueAtWithBinarySearch(users[userAddress].shares, _block);
     }
 
     /// @notice Called to get the current pool shares of a user
@@ -99,49 +97,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns(uint256)
     {
         return userSharesAt(userAddress, block.number);
-    }
-
-    /// @notice Called to get the pool shares of a user at a specific block
-    /// using binary search
-    /// @dev From 
-    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
-    /// This method is not used by the current iteration of the DAO/pool and is
-    /// implemented for future external contracts to use to get the user shares
-    /// at an arbitrary block.
-    /// @param userAddress User address
-    /// @param _block Block number for which the query is being made for
-    /// @return Pool shares of the user at the block
-    function userSharesAtWithBinarySearch(
-        address userAddress,
-        uint256 _block
-        )
-        external
-        view
-        override
-        returns(uint256)
-    {
-        Checkpoint[] storage checkpoints = users[userAddress].shares;
-        if (checkpoints.length == 0)
-            return 0;
-
-        // Shortcut for the actual value
-        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
-            return checkpoints[checkpoints.length - 1].value;
-        if (_block < checkpoints[0].fromBlock)
-            return 0;
-
-        // Binary search of the value in the array
-        uint min = 0;
-        uint max = checkpoints.length - 1;
-        while (max > min) {
-            uint mid = (max + min + 1) / 2;
-            if (checkpoints[mid].fromBlock <= _block) {
-                min = mid;
-            } else {
-                max = mid - 1;
-            }
-        }
-        return checkpoints[min].value;
     }
 
     /// @notice Called to get the current staked tokens of the user
@@ -158,11 +113,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
 
     /// @notice Called to get the voting power delegated to a user at a
     /// specific block
-    /// @dev Starts from the most recent value in `user.delegatedTo` and
-    /// searches backwards one element at a time. If `_block` is within
-    /// `EPOCH_LENGTH`, this call is guaranteed to find the value among
-    /// the last `MAX_INTERACTION_FREQUENCY` elements, which is why it only
-    /// searches through them. 
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Voting power delegated to the user at the block
@@ -175,11 +125,10 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        Checkpoint[] storage delegatedTo = users[userAddress].delegatedTo;
-        uint256 minimumCheckpointIndex = delegatedTo.length > MAX_INTERACTION_FREQUENCY
-            ? delegatedTo.length - MAX_INTERACTION_FREQUENCY
-            : 0;
-        return getValueAt(delegatedTo, _block, minimumCheckpointIndex);
+        return getValueAtWithBinarySearch(
+            users[userAddress].delegatedTo,
+            _block
+            );
     }
 
     /// @notice Called to get the current voting power delegated to a user
@@ -195,11 +144,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the delegate of the user at a specific block
-    /// @dev Starts from the most recent value in `user.delegates` and
-    /// searches backwards one element at a time. If `_block` is within
-    /// `EPOCH_LENGTH`, this call is guaranteed to find the value among
-    /// the last 2 elements because a user cannot update delegate more
-    /// frequently than once an `EPOCH_LENGTH`.
     /// @param userAddress User address
     /// @param _block Block number
     /// @return Delegate of the user at the specific block
@@ -212,15 +156,10 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(address)
     {
-        AddressCheckpoint[] storage delegates = users[userAddress].delegates;
-        for (uint256 i = delegates.length; i > 0; i--)
-        {
-            if (delegates[i - 1].fromBlock <= _block)
-            {
-                return delegates[i - 1]._address;
-            }
-        }
-        return address(0);
+        return getAddressAtWithBinarySearch(
+            users[userAddress].delegates,
+            _block
+            );
     }
 
     /// @notice Called to get the current delegate of the user
@@ -278,30 +217,78 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the value of a checkpoint array at a specific
-    /// block
+    /// block using binary search
+    /// @dev Adapted from 
+    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
     /// @param checkpoints Checkpoints array
     /// @param _block Block number for which the query is being made
     /// @return Value of the checkpoint array at the block
-    function getValueAt(
+    function getValueAtWithBinarySearch(
         Checkpoint[] storage checkpoints,
-        uint256 _block,
-        uint256 minimumCheckpointIndex
+        uint256 _block
         )
-        internal
+        private
         view
         returns(uint256)
     {
-        uint256 i = checkpoints.length;
-        for (; i > minimumCheckpointIndex; i--)
-        {
-            if (checkpoints[i - 1].fromBlock <= _block)
-            {
-                return checkpoints[i - 1].value;
+        if (checkpoints.length == 0)
+            return 0;
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
+            return checkpoints[checkpoints.length - 1].value;
+        if (_block < checkpoints[0].fromBlock)
+            return 0;
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length - 1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock <= _block) {
+                min = mid;
+            } else {
+                max = mid - 1;
             }
         }
-        // Revert if the value being searched for comes before
-        // `minimumCheckpointIndex`
-        require(i == 0, ERROR_VALUE);
-        return 0;
+        return checkpoints[min].value;
+    }
+
+    /// @notice Called to get the value of an address-checkpoint array at a
+    /// specific block using binary search
+    /// @dev Adapted from 
+    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
+    /// @param checkpoints Address-checkpoint array
+    /// @param _block Block number for which the query is being made
+    /// @return Value of the address-checkpoint array at the block
+    function getAddressAtWithBinarySearch(
+        AddressCheckpoint[] storage checkpoints,
+        uint256 _block
+        )
+        private
+        view
+        returns(address)
+    {
+        if (checkpoints.length == 0)
+            return address(0);
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
+            return checkpoints[checkpoints.length - 1]._address;
+        if (_block < checkpoints[0].fromBlock)
+            return address(0);
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length - 1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock <= _block) {
+                min = mid;
+            } else {
+                max = mid - 1;
+            }
+        }
+        return checkpoints[min]._address;
     }
 }

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -40,7 +40,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         external
         override
     {
-        deposit(amount);
+        depositRegular(amount);
         stake(amount);
     }
 
@@ -126,6 +126,6 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         override
     {
         uint256 unstaked = unstake();
-        withdraw(destination, unstaked);
+        withdrawRegular(destination, unstaked);
     }
 }

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -35,21 +35,12 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
     }
 
     /// @notice Convenience method to deposit and stake in a single transaction
-    /// @dev Due to the `deposit()` interface, `userAddress` can only be the
-    /// caller
-    /// @param source Token transfer source
     /// @param amount Amount to be deposited and staked
-    /// @param userAddress User that the tokens will be staked for
-    function depositAndStake(
-        address source,
-        uint256 amount,
-        address userAddress
-        )
+    function depositAndStake(uint256 amount)
         external
         override
     {
-        require(userAddress == msg.sender, ERROR_UNAUTHORIZED);
-        deposit(source, amount, userAddress);
+        deposit(amount);
         stake(amount);
     }
 

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -207,6 +207,7 @@ contract StateUtils is IStateUtils {
         address timelockManagerAddress
         )
     {
+        require(timelockManagerAddress != address(0), "Invalid TimelockManager");
         api3Token = IApi3Token(api3TokenAddress);
         timelockManager = timelockManagerAddress;
         // Initialize the share price at 1

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -526,37 +526,4 @@ contract StateUtils is IStateUtils {
             }
         }
     }
-
-    /// @notice Called internally to update an address checkpoint array
-    /// @param addressCheckpointArray Address checkpoint array to be updated
-    /// @param _address Address to be updated with
-    function updateAddressCheckpointArray(
-        AddressCheckpoint[] storage addressCheckpointArray,
-        address _address
-        )
-        internal
-    {
-        if (addressCheckpointArray.length == 0)
-        {
-            addressCheckpointArray.push(AddressCheckpoint({
-                fromBlock: lastVoteSnapshotBlock,
-                _address: _address
-                }));
-        }
-        else
-        {
-            AddressCheckpoint storage lastElement = addressCheckpointArray[addressCheckpointArray.length - 1];
-            if (lastElement.fromBlock < lastVoteSnapshotBlock)
-            {
-                addressCheckpointArray.push(AddressCheckpoint({
-                    fromBlock: lastVoteSnapshotBlock,
-                    _address: _address
-                    }));
-            }
-            else
-            {
-                lastElement._address = _address;
-            }
-        }
-    }
 }

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -75,6 +75,9 @@ contract StateUtils is IStateUtils {
     /// @notice API3 token contract
     IApi3Token public api3Token;
 
+    /// @notice TimelockManager contract
+    address public timelockManager;
+
     /// @notice Address of the primary Agent app of the API3 DAO
     /// @dev Primary Agent can be operated through the primary Api3Voting app.
     /// The primary Api3Voting app requires a higher quorum, and the primary
@@ -199,9 +202,13 @@ contract StateUtils is IStateUtils {
     }
 
     /// @param api3TokenAddress API3 token contract address
-    constructor(address api3TokenAddress)
+    constructor(
+        address api3TokenAddress,
+        address timelockManagerAddress
+        )
     {
         api3Token = IApi3Token(api3TokenAddress);
+        timelockManager = timelockManagerAddress;
         // Initialize the share price at 1
         updateTotalShares(1);
         totalStake = 1;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -36,7 +36,6 @@ contract StateUtils is IStateUtils {
     struct LockedCalculationState {
         uint256 initialIndEpoch;
         uint256 nextIndEpoch;
-        uint256 nextIndUserShares;
         uint256 locked;
     }
 

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -33,6 +33,14 @@ contract StateUtils is IStateUtils {
         uint256 unstakeAmount;
     }
 
+    struct LockedCalculationState {
+        uint256 initialIndEpoch;
+        uint256 initialUserSharesLength;
+        uint256 nextIndEpoch;
+        uint256 nextIndUserShares;
+        uint256 locked;
+    }
+
     /// @notice Length of the epoch in which the staking reward is paid out
     /// once. It is hardcoded as 7 days in seconds.
     /// @dev In addition to regulating reward payments, this variable is used
@@ -104,6 +112,7 @@ contract StateUtils is IStateUtils {
 
     /// @notice User records
     mapping(address => User) public users;
+    mapping(address => LockedCalculationState) internal userToLockedCalculationState;
 
     /// @notice Total number of tokens staked at the pool
     uint256 public totalStake;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -35,7 +35,6 @@ contract StateUtils is IStateUtils {
 
     struct LockedCalculationState {
         uint256 initialIndEpoch;
-        uint256 initialUserSharesLength;
         uint256 nextIndEpoch;
         uint256 nextIndUserShares;
         uint256 locked;

--- a/packages/pool/contracts/TimelockUtils.sol
+++ b/packages/pool/contracts/TimelockUtils.sol
@@ -24,6 +24,32 @@ abstract contract TimelockUtils is ClaimUtils, ITimelockUtils {
     mapping(address => Timelock) public userToTimelock;
 
     /// @notice Called by the TimelockManager contract to deposit tokens on
+    /// behalf of a user
+    /// @dev This method is only usable by `TimelockManager.sol`.
+    /// It is named as `deposit()` and not `depositByTimelockManager()` for
+    /// example because the TimelockManager is already deployed and expects the
+    /// `deposit(address,uint256,address)` interface.
+    /// @param source Token transfer source
+    /// @param amount Amount to be deposited
+    /// @param userAddress User that the tokens will be deposited for
+    function deposit(
+        address source,
+        uint256 amount,
+        address userAddress
+        )
+        external
+        override
+    {
+        require(msg.sender == timelockManager, "Caller not TimelockManager");
+        users[userAddress].unstaked = users[userAddress].unstaked + amount;
+        api3Token.transferFrom(source, address(this), amount);
+        emit DepositedByTimelockManager(
+            userAddress,
+            amount
+            );
+    }
+
+    /// @notice Called by the TimelockManager contract to deposit tokens on
     /// behalf of a user on a linear vesting schedule
     /// @dev Refer to `TimelockManager.sol` to see how this is used
     /// @param source Token source

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -70,15 +70,10 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         require(userSharesLength != 0, "User never had shares");
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[userAddress];
-        // Reset the state if the epoch has passed or the user has updated
-        // their staking status
-        if (
-            state.initialIndEpoch != currentEpoch
-                || state.initialUserSharesLength != userSharesLength
-            )
+        // Reset the state if there was no calculation made in this epoch
+        if (state.initialIndEpoch != currentEpoch)
         {
             state.initialIndEpoch = currentEpoch;
-            state.initialUserSharesLength = userSharesLength;
             state.nextIndEpoch = currentEpoch;
             state.nextIndUserShares = userSharesLength - 1;
             state.locked = 0;
@@ -140,11 +135,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         payReward();
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[msg.sender];
-        require(
-            state.initialIndEpoch == currentEpoch 
-                && state.initialUserSharesLength == users[msg.sender].shares.length,
-            "Locked amount not precalculated"
-            );
+        require(state.initialIndEpoch == currentEpoch, "Locked amount not precalculated");
         withdraw(destination, amount, state.locked);
     }
 

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -7,23 +7,16 @@ import "./interfaces/ITransferUtils.sol";
 /// @title Contract that implements token transfer functionality
 abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     /// @notice Called to deposit tokens for a user by using `transferFrom()`
-    /// @dev This method is used by `TimelockManager.sol`
-    /// @param source Token transfer source
     /// @param amount Amount to be deposited
-    /// @param userAddress User that the tokens will be deposited for
-    function deposit(
-        address source,
-        uint256 amount,
-        address userAddress
-        )
+    function deposit(uint256 amount)
         public
         override
     {
         payReward();
-        users[userAddress].unstaked = users[userAddress].unstaked + amount;
-        api3Token.transferFrom(source, address(this), amount);
+        users[msg.sender].unstaked = users[msg.sender].unstaked + amount;
+        api3Token.transferFrom(msg.sender, address(this), amount);
         emit Deposited(
-            userAddress,
+            msg.sender,
             amount
             );
     }

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -6,7 +6,7 @@ import "./interfaces/ITransferUtils.sol";
 
 /// @title Contract that implements token transfer functionality
 abstract contract TransferUtils is DelegationUtils, ITransferUtils {
-    /// @notice Called to deposit tokens for a user by using `transferFrom()`
+    /// @notice Called to deposit tokens for a user
     /// @param amount Amount to be deposited
     function deposit(uint256 amount)
         public

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -6,9 +6,14 @@ import "./interfaces/ITransferUtils.sol";
 
 /// @title Contract that implements token transfer functionality
 abstract contract TransferUtils is DelegationUtils, ITransferUtils {
-    /// @notice Called to deposit tokens for a user
+    /// @notice Called by the user to deposit tokens
+    /// @dev The user should approve the pool to spend at least `amount` tokens
+    /// before calling this.
+    /// The method is named `depositRegular()` to prevent potential confusion
+    /// (for example it is difficult to differentiate overloaded functions in
+    /// JS). See `deposit()` for more context.
     /// @param amount Amount to be deposited
-    function deposit(uint256 amount)
+    function depositRegular(uint256 amount)
         public
         override
     {
@@ -21,12 +26,14 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
             );
     }
 
-    /// @notice Called to withdraw tokens
+    /// @notice Called by the user to withdraw tokens
     /// @dev The user should call `getUserLocked()` beforehand to ensure that
-    /// they have at least `amount` unlocked tokens to withdraw
+    /// they have at least `amount` unlocked tokens to withdraw.
+    /// The method is named `withdrawRegular()` to be consistent with the name
+    /// `depositRegular()`. See `depositRegular()` for more context.
     /// @param destination Token transfer destination
     /// @param amount Amount to be withdrawn
-    function withdraw(
+    function withdrawRegular(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -55,7 +55,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     /// @param userAddress User address
     /// @param noEpochsPerIteration Number of epochs per iteration
     /// @return finished Calculation has finished in this call
-    function calculateUserLockedIteratively(
+    function precalculateUserLocked(
         address userAddress,
         uint256 noEpochsPerIteration
         )
@@ -109,12 +109,12 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     }
 
     /// @notice Called by the user to withdraw after their locked token amount
-    /// is calculated with repeated calls to `calculateUserLockedIteratively()`
-    /// @dev Only use `calculateUserLockedIteratively()` and this method if
+    /// is calculated with repeated calls to `precalculateUserLocked()`
+    /// @dev Only use `precalculateUserLocked()` and this method if
     /// `withdrawRegular()` hits the block gas limit
     /// @param destination Token transfer destination
     /// @param amount Amount to be withdrawn
-    function withdrawWithPrecalculatedLocked(
+    function withdrawPrecalculated(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -40,14 +40,6 @@ interface IGetterUtils is IStateUtils {
         view
         returns(uint256);
 
-    function userSharesAtWithBinarySearch(
-        address userAddress,
-        uint256 _block
-        )
-        external
-        view
-        returns(uint256);
-
     function userStake(address userAddress)
         external
         view

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -25,11 +25,7 @@ interface IStakeUtils is ITransferUtils{
     function stake(uint256 amount)
         external;
 
-    function depositAndStake(
-        address source,
-        uint256 amount,
-        address userAddress
-        )
+    function depositAndStake(uint256 amount)
         external;
 
     function scheduleUnstake(uint256 amount)

--- a/packages/pool/contracts/interfaces/ITimelockUtils.sol
+++ b/packages/pool/contracts/interfaces/ITimelockUtils.sol
@@ -4,6 +4,11 @@ pragma solidity 0.8.2;
 import "./IClaimUtils.sol";
 
 interface ITimelockUtils is IClaimUtils {
+    event DepositedByTimelockManager(
+        address indexed user,
+        uint256 amount
+        );
+
     event DepositedVesting(
         address indexed user,
         uint256 amount,
@@ -15,6 +20,13 @@ interface ITimelockUtils is IClaimUtils {
         address indexed user,
         uint256 remainingAmount
         );
+
+    function deposit(
+        address source,
+        uint256 amount,
+        address userAddress
+        )
+        external;
 
     function depositWithVesting(
         address source,

--- a/packages/pool/contracts/interfaces/ITimelockUtils.sol
+++ b/packages/pool/contracts/interfaces/ITimelockUtils.sol
@@ -13,7 +13,6 @@ interface ITimelockUtils is IClaimUtils {
 
     event UpdatedTimelock(
         address indexed user,
-        address indexed timelockManagerAddress,
         uint256 remainingAmount
         );
 
@@ -26,9 +25,6 @@ interface ITimelockUtils is IClaimUtils {
         )
         external;
 
-    function updateTimelockStatus(
-        address userAddress,
-        address timelockManagerAddress
-        )
+    function updateTimelockStatus(address userAddress)
         external;
 }

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -15,10 +15,10 @@ interface ITransferUtils is IDelegationUtils{
         uint256 amount
         );
 
-    function deposit(uint256 amount)
+    function depositRegular(uint256 amount)
         external;
 
-    function withdraw(
+    function withdrawRegular(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -15,11 +15,7 @@ interface ITransferUtils is IDelegationUtils{
         uint256 amount
         );
 
-    function deposit(
-        address source,
-        uint256 amount,
-        address userAddress
-        )
+    function deposit(uint256 amount)
         external;
 
     function withdraw(

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -15,10 +15,34 @@ interface ITransferUtils is IDelegationUtils{
         uint256 amount
         );
 
+    event CalculatingUserLocked(
+        address indexed user,
+        uint256 nextIndEpoch,
+        uint256 oldestLockedEpoch
+        );
+
+    event CalculatedUserLocked(
+        address indexed user,
+        uint256 amount
+        );
+
     function depositRegular(uint256 amount)
         external;
 
     function withdrawRegular(
+        address destination,
+        uint256 amount
+        )
+        external;
+
+    function calculateUserLockedIteratively(
+        address userAddress,
+        uint256 noEpochsPerIteration
+        )
+        external
+        returns (bool finished);
+
+    function withdrawWithPrecalculatedLocked(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -35,14 +35,14 @@ interface ITransferUtils is IDelegationUtils{
         )
         external;
 
-    function calculateUserLockedIteratively(
+    function precalculateUserLocked(
         address userAddress,
         uint256 noEpochsPerIteration
         )
         external
         returns (bool finished);
 
-    function withdrawWithPrecalculatedLocked(
+    function withdrawPrecalculated(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/mock/MockApi3Staker.sol
+++ b/packages/pool/contracts/mock/MockApi3Staker.sol
@@ -24,15 +24,7 @@ contract MockApi3Staker {
         external
     {
         api3Token.approve(address(api3Pool), amount1 + amount2);
-        api3Pool.depositAndStake(
-          address(this),
-          amount1,
-          address(this)
-          );
-        api3Pool.depositAndStake(
-          address(this),
-          amount2,
-          address(this)
-          );
+        api3Pool.depositAndStake(amount1);
+        api3Pool.depositAndStake(amount2);
     }
 }

--- a/packages/pool/deploy/1_deploy.js
+++ b/packages/pool/deploy/1_deploy.js
@@ -5,16 +5,23 @@ module.exports = async ({ getUnnamedAccounts, deployments, network }) => {
   if (network.name == "mainnet") {
     await deploy("Api3Pool", {
       from: accounts[0],
-      args: ["0x0b38210ea11411557c13457D4dA7dC6ea731B88a"],
+      args: [
+        "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+        "0xFaef86994a37F1c8b2A5c73648F07dd4eFF02baA",
+      ],
     });
   } else {
     const api3Token = await deploy("Api3Token", {
       from: accounts[0],
       args: [accounts[0], accounts[0]],
     });
+    const timelockManager = await deploy("TimelockManager", {
+      from: accounts[0],
+      args: [api3Token.address, accounts[0]],
+    });
     await deploy("Api3Pool", {
       from: accounts[0],
-      args: [api3Token.address],
+      args: [api3Token.address, timelockManager.address],
     });
   }
 };

--- a/packages/pool/test/ClaimUtils.sol.js
+++ b/packages/pool/test/ClaimUtils.sol.js
@@ -14,6 +14,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -28,7 +29,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
 });
 
 describe("payOutClaim", function () {

--- a/packages/pool/test/ClaimUtils.sol.js
+++ b/packages/pool/test/ClaimUtils.sol.js
@@ -60,13 +60,7 @@ describe("payOutClaim", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
         // Pay out claim
         const claimAmount = ethers.utils.parseEther("5" + "000" + "000");
         await expect(

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -58,69 +58,63 @@ describe("delegateVotingPower", function () {
           "User has not updated their delegation status less than reward epoch ago",
           function () {
             context("User did not have the same delegate", function () {
-                  it("delegates voting power", async function () {
-                    // Have two users stake
-                    const user1Stake = ethers.utils.parseEther(
-                      "20" + "000" + "000"
-                    );
-                    const user2Stake = ethers.utils.parseEther(
-                      "60" + "000" + "000"
-                    );
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(roles.user1.address, user1Stake);
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(roles.user2.address, user2Stake);
-                    await api3Token
-                      .connect(roles.user1)
-                      .approve(api3Pool.address, user1Stake);
-                    await api3Token
-                      .connect(roles.user2)
-                      .approve(api3Pool.address, user2Stake);
-                    await api3Pool
-                      .connect(roles.user1)
-                      .depositAndStake(user1Stake);
-                    await api3Pool
-                      .connect(roles.user2)
-                      .depositAndStake(user2Stake);
-                    // Have user 1 delegate to someone else first
-                    await api3Pool
-                      .connect(roles.user1)
-                      .delegateVotingPower(roles.randomPerson.address);
-                    expect(
-                      await api3Pool.balanceOf(roles.user1.address)
-                    ).to.equal(ethers.BigNumber.from(0));
-                    expect(
-                      await api3Pool.balanceOf(roles.randomPerson.address)
-                    ).to.equal(user1Stake);
-                    // Fast forward time
-                    await ethers.provider.send("evm_increaseTime", [
-                      EPOCH_LENGTH.toNumber(),
-                    ]);
-                    // ... then have user 1 delegate to user 2
-                    await expect(
-                      api3Pool
-                        .connect(roles.user1)
-                        .delegateVotingPower(roles.user2.address)
-                    )
-                      .to.emit(api3Pool, "Delegated")
-                      .withArgs(roles.user1.address, roles.user2.address);
-                    expect(
-                      await api3Pool.balanceOf(roles.user1.address)
-                    ).to.equal(ethers.BigNumber.from(0));
-                    expect(
-                      await api3Pool.balanceOf(roles.user2.address)
-                    ).to.equal(user2Stake.add(user1Stake));
-                    expect(
-                      await api3Pool.userReceivedDelegation(roles.user2.address)
-                    ).to.equal(user1Stake);
-                    expect(
-                      await api3Pool.userDelegate(roles.user1.address)
-                    ).to.equal(roles.user2.address);
-                  });
-                
-              
+              it("delegates voting power", async function () {
+                // Have two users stake
+                const user1Stake = ethers.utils.parseEther(
+                  "20" + "000" + "000"
+                );
+                const user2Stake = ethers.utils.parseEther(
+                  "60" + "000" + "000"
+                );
+                await api3Token
+                  .connect(roles.deployer)
+                  .transfer(roles.user1.address, user1Stake);
+                await api3Token
+                  .connect(roles.deployer)
+                  .transfer(roles.user2.address, user2Stake);
+                await api3Token
+                  .connect(roles.user1)
+                  .approve(api3Pool.address, user1Stake);
+                await api3Token
+                  .connect(roles.user2)
+                  .approve(api3Pool.address, user2Stake);
+                await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+                await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
+                // Have user 1 delegate to someone else first
+                await api3Pool
+                  .connect(roles.user1)
+                  .delegateVotingPower(roles.randomPerson.address);
+                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
+                  ethers.BigNumber.from(0)
+                );
+                expect(
+                  await api3Pool.balanceOf(roles.randomPerson.address)
+                ).to.equal(user1Stake);
+                // Fast forward time
+                await ethers.provider.send("evm_increaseTime", [
+                  EPOCH_LENGTH.toNumber(),
+                ]);
+                // ... then have user 1 delegate to user 2
+                await expect(
+                  api3Pool
+                    .connect(roles.user1)
+                    .delegateVotingPower(roles.user2.address)
+                )
+                  .to.emit(api3Pool, "Delegated")
+                  .withArgs(roles.user1.address, roles.user2.address);
+                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
+                  ethers.BigNumber.from(0)
+                );
+                expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
+                  user2Stake.add(user1Stake)
+                );
+                expect(
+                  await api3Pool.userReceivedDelegation(roles.user2.address)
+                ).to.equal(user1Stake);
+                expect(
+                  await api3Pool.userDelegate(roles.user1.address)
+                ).to.equal(roles.user2.address);
+              });
             });
             context("User had the same delegate", function () {
               it("reverts", async function () {

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -84,18 +84,10 @@ describe("delegateVotingPower", function () {
                       .approve(api3Pool.address, user2Stake);
                     await api3Pool
                       .connect(roles.user1)
-                      .depositAndStake(
-                        roles.user1.address,
-                        user1Stake,
-                        roles.user1.address
-                      );
+                      .depositAndStake(user1Stake);
                     await api3Pool
                       .connect(roles.user2)
-                      .depositAndStake(
-                        roles.user2.address,
-                        user2Stake,
-                        roles.user2.address
-                      );
+                      .depositAndStake(user2Stake);
                     // Have user 1 delegate to someone else first
                     await api3Pool
                       .connect(roles.user1)
@@ -156,12 +148,7 @@ describe("delegateVotingPower", function () {
                         });
                       await api3Pool
                         .connect(randomWallet)
-                        .depositAndStake(
-                          randomWallet.address,
-                          amount,
-                          randomWallet.address,
-                          { gasLimit: 500000 }
-                        );
+                        .depositAndStake(amount, { gasLimit: 500000 });
                       await api3Pool
                         .connect(randomWallet)
                         .delegateVotingPower(roles.user1.address, {
@@ -185,12 +172,7 @@ describe("delegateVotingPower", function () {
                       .approve(api3Pool.address, amount, { gasLimit: 500000 });
                     await api3Pool
                       .connect(randomWallet)
-                      .depositAndStake(
-                        randomWallet.address,
-                        amount,
-                        randomWallet.address,
-                        { gasLimit: 500000 }
-                      );
+                      .depositAndStake(amount, { gasLimit: 500000 });
                     await expect(
                       api3Pool
                         .connect(randomWallet)
@@ -223,20 +205,8 @@ describe("delegateVotingPower", function () {
                 await api3Token
                   .connect(roles.user2)
                   .approve(api3Pool.address, user2Stake);
-                await api3Pool
-                  .connect(roles.user1)
-                  .depositAndStake(
-                    roles.user1.address,
-                    user1Stake,
-                    roles.user1.address
-                  );
-                await api3Pool
-                  .connect(roles.user2)
-                  .depositAndStake(
-                    roles.user2.address,
-                    user2Stake,
-                    roles.user2.address
-                  );
+                await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+                await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
                 // Have user 1 delegate to user 2
                 await api3Pool
                   .connect(roles.user1)
@@ -335,20 +305,8 @@ describe("undelegateVotingPower", function () {
           await api3Token
             .connect(roles.user2)
             .approve(api3Pool.address, user2Stake);
-          await api3Pool
-            .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake,
-              roles.user1.address
-            );
-          await api3Pool
-            .connect(roles.user2)
-            .depositAndStake(
-              roles.user2.address,
-              user2Stake,
-              roles.user2.address
-            );
+          await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+          await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
           // Have user 1 delegate to user 2 first
           await api3Pool
             .connect(roles.user1)

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting;
-let EPOCH_LENGTH, MAX_INTERACTION_FREQUENCY;
+let EPOCH_LENGTH;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -48,7 +48,6 @@ beforeEach(async () => {
       roles.votingAppSecondary.address
     );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
-  MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
 describe("delegateVotingPower", function () {
@@ -59,9 +58,6 @@ describe("delegateVotingPower", function () {
           "User has not updated their delegation status less than reward epoch ago",
           function () {
             context("User did not have the same delegate", function () {
-              context(
-                "Receiving user has not been delegated to too frequently",
-                function () {
                   it("delegates voting power", async function () {
                     // Have two users stake
                     const user1Stake = ethers.utils.parseEther(
@@ -123,66 +119,8 @@ describe("delegateVotingPower", function () {
                       await api3Pool.userDelegate(roles.user1.address)
                     ).to.equal(roles.user2.address);
                   });
-                }
-              );
-              context(
-                "Receiving user has been delegated to too frequently",
-                function () {
-                  it("reverts", async function () {
-                    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-                      const randomWallet = ethers.Wallet.createRandom().connect(
-                        ethers.provider
-                      );
-                      await roles.deployer.sendTransaction({
-                        to: randomWallet.address,
-                        value: ethers.utils.parseEther("1"),
-                      });
-                      const amount = ethers.BigNumber.from(1000);
-                      await api3Token
-                        .connect(roles.deployer)
-                        .transfer(randomWallet.address, amount);
-                      await api3Token
-                        .connect(randomWallet)
-                        .approve(api3Pool.address, amount, {
-                          gasLimit: 500000,
-                        });
-                      await api3Pool
-                        .connect(randomWallet)
-                        .depositAndStake(amount, { gasLimit: 500000 });
-                      await api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        });
-                      await api3Voting.newVote();
-                    }
-                    const randomWallet = ethers.Wallet.createRandom().connect(
-                      ethers.provider
-                    );
-                    await roles.deployer.sendTransaction({
-                      to: randomWallet.address,
-                      value: ethers.utils.parseEther("1"),
-                    });
-                    const amount = ethers.BigNumber.from(1000);
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(randomWallet.address, amount);
-                    await api3Token
-                      .connect(randomWallet)
-                      .approve(api3Pool.address, amount, { gasLimit: 500000 });
-                    await api3Pool
-                      .connect(randomWallet)
-                      .depositAndStake(amount, { gasLimit: 500000 });
-                    await expect(
-                      api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        })
-                    ).to.be.revertedWith("Try again a week later");
-                  });
-                }
-              );
+                
+              
             });
             context("User had the same delegate", function () {
               it("reverts", async function () {

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -15,6 +15,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -29,7 +30,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
   const api3VotingFactory = await ethers.getContractFactory(
     "MockApi3Voting",
     roles.deployer
@@ -243,10 +247,10 @@ describe("delegateVotingPower", function () {
                 ]);
                 // ... then have user 1 delegate to user 2 again
                 await expect(
-                api3Pool
-                  .connect(roles.user1)
-                  .delegateVotingPower(roles.user2.address)
-                 ).to.be.revertedWith("Cannot delegate to the same address");
+                  api3Pool
+                    .connect(roles.user1)
+                    .delegateVotingPower(roles.user2.address)
+                ).to.be.revertedWith("Cannot delegate to the same address");
 
                 expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
                   ethers.BigNumber.from(0)

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -153,29 +153,26 @@ describe("userReceivedDelegationAt", function () {
 
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
-    await api3Voting.newVote();
-    const firstBlockNumber = await ethers.provider.getBlockNumber();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
-    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
-      ethers.constants.AddressZero
-    );
+    const firstBlockNumber = await ethers.provider.getBlockNumber();
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
-    await api3Voting.newVote();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.randomPerson.address);
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
-    await api3Voting.newVote();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     // Check delegates
+    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
+      ethers.constants.AddressZero
+    );
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber)
     ).to.equal(roles.user2.address);
@@ -184,9 +181,6 @@ describe("getDelegateAt", function () {
     ).to.equal(roles.randomPerson.address);
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber + 2)
-    ).to.equal(roles.randomPerson.address);
-    expect(
-      await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber + 3)
     ).to.equal(roles.user2.address);
   });
 });

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -17,6 +17,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -31,7 +32,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
   const api3VotingFactory = await ethers.getContractFactory(
     "MockApi3Voting",
     roles.deployer

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -109,156 +109,58 @@ describe("userSharesAt", function () {
   });
 });
 
-describe("userSharesAtWithBinarySearch", function () {
-  it("gets user shares at", async function () {
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(roles.user1.address, 0)
-    ).to.equal(ethers.BigNumber.from(0));
-    const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-    await api3Token
-      .connect(roles.deployer)
-      .transfer(roles.user1.address, user1Stake);
-    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
-    await api3Pool.connect(roles.user1).depositRegular(user1Stake);
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    const currentBlockNumber = await ethers.provider.getBlockNumber();
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber
-      )
-    ).to.equal(ethers.BigNumber.from(3));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 1
-      )
-    ).to.equal(ethers.BigNumber.from(2));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 2
-      )
-    ).to.equal(ethers.BigNumber.from(1));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 3
-      )
-    ).to.equal(ethers.BigNumber.from(0));
-  });
-});
-
 describe("userReceivedDelegationAt", function () {
-  context("Searched block is within MAX_INTERACTION_FREQUENCY", function () {
-    it("gets user's received delegation at the block", async function () {
-      const genesisEpoch = await api3Pool.genesisEpoch();
-      const amount = ethers.BigNumber.from(1000);
-      const delegationBlocks = [];
-      for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-        await api3Voting.newVote();
-        delegationBlocks.push(await ethers.provider.getBlockNumber());
-        const randomWallet = ethers.Wallet.createRandom().connect(
-          ethers.provider
-        );
-        await roles.deployer.sendTransaction({
-          to: randomWallet.address,
-          value: ethers.utils.parseEther("1"),
-        });
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(randomWallet.address, amount);
-        await api3Token
-          .connect(randomWallet)
-          .approve(api3Pool.address, amount, { gasLimit: 500000 });
-        await api3Pool.connect(randomWallet).depositAndStake(amount, {
-          gasLimit: 500000,
-        });
-        await api3Pool
-          .connect(randomWallet)
-          .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
-        await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
-        ]);
-      }
-      for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-        expect(
-          await api3Pool.userReceivedDelegationAt(
-            roles.user1.address,
-            delegationBlocks[i]
-          )
-        ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
-      }
-    });
-  });
-  context(
-    "Searched block is not within MAX_INTERACTION_FREQUENCY",
-    function () {
-      it("reverts", async function () {
-        const genesisEpoch = await api3Pool.genesisEpoch();
-        const amount = ethers.BigNumber.from(1000);
-        const delegationBlocks = [];
-        for (
-          let i = 0;
-          i < MAX_INTERACTION_FREQUENCY.add(ethers.BigNumber.from(1));
-          i++
-        ) {
-          await api3Voting.newVote();
-          delegationBlocks.push(await ethers.provider.getBlockNumber());
-          const randomWallet = ethers.Wallet.createRandom().connect(
-            ethers.provider
-          );
-          await roles.deployer.sendTransaction({
-            to: randomWallet.address,
-            value: ethers.utils.parseEther("1"),
-          });
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(randomWallet.address, amount);
-          await api3Token
-            .connect(randomWallet)
-            .approve(api3Pool.address, amount, { gasLimit: 500000 });
-          await api3Pool
-            .connect(randomWallet)
-            .depositAndStake(amount, { gasLimit: 500000 });
-          await api3Pool
-            .connect(randomWallet)
-            .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
-          await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
-          ]);
-        }
-        for (
-          let i = 1;
-          i < MAX_INTERACTION_FREQUENCY.add(ethers.BigNumber.from(1));
-          i++
-        ) {
-          expect(
-            await api3Pool.userReceivedDelegationAt(
-              roles.user1.address,
-              delegationBlocks[i]
-            )
-          ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
-        }
-        await expect(
-          api3Pool.userReceivedDelegationAt(
-            roles.user1.address,
-            delegationBlocks[0]
-          )
-        ).to.be.revertedWith("Invalid value");
+  it("gets user's received delegation at the block", async function () {
+    const genesisEpoch = await api3Pool.genesisEpoch();
+    const amount = ethers.BigNumber.from(1000);
+    const delegationBlocks = [];
+    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+      await api3Voting.newVote();
+      delegationBlocks.push(await ethers.provider.getBlockNumber());
+      const randomWallet = ethers.Wallet.createRandom().connect(
+        ethers.provider
+      );
+      await roles.deployer.sendTransaction({
+        to: randomWallet.address,
+        value: ethers.utils.parseEther("1"),
       });
+      await api3Token
+        .connect(roles.deployer)
+        .transfer(randomWallet.address, amount);
+      await api3Token
+        .connect(randomWallet)
+        .approve(api3Pool.address, amount, { gasLimit: 500000 });
+      await api3Pool.connect(randomWallet).depositAndStake(amount, {
+        gasLimit: 500000,
+      });
+      await api3Pool
+        .connect(randomWallet)
+        .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
+      ]);
     }
-  );
+    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+      expect(
+        await api3Pool.userReceivedDelegationAt(
+          roles.user1.address,
+          delegationBlocks[i]
+        )
+      ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
+    }
+  });
 });
 
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
+    await api3Voting.newVote();
     const firstBlockNumber = await ethers.provider.getBlockNumber();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
+    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
+      ethers.constants.AddressZero
+    );
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     await api3Voting.newVote();
@@ -274,9 +176,6 @@ describe("getDelegateAt", function () {
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     // Check delegates
-    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
-      roles.user2.address
-    );
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber)
     ).to.equal(roles.user2.address);

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -87,10 +87,9 @@ describe("userSharesAt", function () {
     const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
     await api3Token
       .connect(roles.deployer)
-      .approve(api3Pool.address, user1Stake);
-    await api3Pool
-      .connect(roles.randomPerson)
-      .deposit(roles.deployer.address, user1Stake, roles.user1.address);
+      .transfer(roles.user1.address, user1Stake);
+    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
+    await api3Pool.connect(roles.user1).deposit(user1Stake);
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
@@ -118,10 +117,9 @@ describe("userSharesAtWithBinarySearch", function () {
     const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
     await api3Token
       .connect(roles.deployer)
-      .approve(api3Pool.address, user1Stake);
-    await api3Pool
-      .connect(roles.randomPerson)
-      .deposit(roles.deployer.address, user1Stake, roles.user1.address);
+      .transfer(roles.user1.address, user1Stake);
+    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
+    await api3Pool.connect(roles.user1).deposit(user1Stake);
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
@@ -175,11 +173,9 @@ describe("userReceivedDelegationAt", function () {
         await api3Token
           .connect(randomWallet)
           .approve(api3Pool.address, amount, { gasLimit: 500000 });
-        await api3Pool
-          .connect(randomWallet)
-          .depositAndStake(randomWallet.address, amount, randomWallet.address, {
-            gasLimit: 500000,
-          });
+        await api3Pool.connect(randomWallet).depositAndStake(amount, {
+          gasLimit: 500000,
+        });
         await api3Pool
           .connect(randomWallet)
           .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
@@ -226,12 +222,7 @@ describe("userReceivedDelegationAt", function () {
             .approve(api3Pool.address, amount, { gasLimit: 500000 });
           await api3Pool
             .connect(randomWallet)
-            .depositAndStake(
-              randomWallet.address,
-              amount,
-              randomWallet.address,
-              { gasLimit: 500000 }
-            );
+            .depositAndStake(amount, { gasLimit: 500000 });
           await api3Pool
             .connect(randomWallet)
             .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
@@ -321,11 +312,7 @@ describe("getUserLocked", function () {
             .approve(api3Pool.address, user1Stake);
           await api3Pool
             .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake.div(2),
-              roles.user1.address
-            );
+            .depositAndStake(user1Stake.div(2));
           const genesisEpoch = await api3Pool.genesisEpoch();
           const userRewards = [];
           for (let i = 1; i < REWARD_VESTING_PERIOD.mul(2); i++) {
@@ -346,11 +333,7 @@ describe("getUserLocked", function () {
               // Stake some more
               await api3Pool
                 .connect(roles.user1)
-                .depositAndStake(
-                  roles.user1.address,
-                  user1Stake.div(1000),
-                  roles.user1.address
-                );
+                .depositAndStake(user1Stake.div(1000));
             } else {
               userRewards.push(ethers.BigNumber.from(0));
             }
@@ -399,13 +382,7 @@ describe("getUserLocked", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake.div(2),
-            roles.user1.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake.div(2));
         const genesisEpoch = await api3Pool.genesisEpoch();
         const userRewards = [];
         for (let i = 1; i < REWARD_VESTING_PERIOD.div(2); i++) {
@@ -426,11 +403,7 @@ describe("getUserLocked", function () {
             // Stake some more
             await api3Pool
               .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake.div(1000),
-                roles.user1.address
-              );
+              .depositAndStake(user1Stake.div(1000));
           } else {
             userRewards.push(ethers.BigNumber.from(0));
           }

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -89,7 +89,7 @@ describe("userSharesAt", function () {
       .connect(roles.deployer)
       .transfer(roles.user1.address, user1Stake);
     await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
-    await api3Pool.connect(roles.user1).deposit(user1Stake);
+    await api3Pool.connect(roles.user1).depositRegular(user1Stake);
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
@@ -119,7 +119,7 @@ describe("userSharesAtWithBinarySearch", function () {
       .connect(roles.deployer)
       .transfer(roles.user1.address, user1Stake);
     await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
-    await api3Pool.connect(roles.user1).deposit(user1Stake);
+    await api3Pool.connect(roles.user1).depositRegular(user1Stake);
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
     await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -4,7 +4,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting, api3Staker;
-let EPOCH_LENGTH, REWARD_VESTING_PERIOD, MAX_INTERACTION_FREQUENCY;
+let EPOCH_LENGTH, REWARD_VESTING_PERIOD;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -59,7 +59,6 @@ beforeEach(async () => {
   );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
   REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
-  MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
 describe("totalSupplyOneBlockAgo", function () {
@@ -113,8 +112,9 @@ describe("userReceivedDelegationAt", function () {
   it("gets user's received delegation at the block", async function () {
     const genesisEpoch = await api3Pool.genesisEpoch();
     const amount = ethers.BigNumber.from(1000);
+    const noDelegations = 20;
     const delegationBlocks = [];
-    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+    for (let i = 0; i < noDelegations; i++) {
       await api3Voting.newVote();
       delegationBlocks.push(await ethers.provider.getBlockNumber());
       const randomWallet = ethers.Wallet.createRandom().connect(
@@ -140,7 +140,7 @@ describe("userReceivedDelegationAt", function () {
         genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
       ]);
     }
-    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+    for (let i = 0; i < noDelegations; i++) {
       expect(
         await api3Pool.userReceivedDelegationAt(
           roles.user1.address,

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -18,6 +18,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -32,7 +33,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
   REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
 });

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -66,20 +66,8 @@ describe("payReward", function () {
             await api3Token
               .connect(roles.user2)
               .approve(api3Pool.address, user2Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            await api3Pool
-              .connect(roles.user2)
-              .depositAndStake(
-                roles.user2.address,
-                user2Stake,
-                roles.user2.address
-              );
+            await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+            await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
             // Fast forward time to one epoch into the future
             const genesisEpoch = await api3Pool.genesisEpoch();
             let nextEpoch = genesisEpoch;
@@ -153,20 +141,8 @@ describe("payReward", function () {
             await api3Token
               .connect(roles.user2)
               .approve(api3Pool.address, user2Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
-            await api3Pool
-              .connect(roles.user2)
-              .depositAndStake(
-                roles.user2.address,
-                user2Stake,
-                roles.user2.address
-              );
+            await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+            await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
             // Fast forward time to one epoch into the future
             const genesisEpoch = await api3Pool.genesisEpoch();
             const genesisEpochPlusOne = genesisEpoch.add(
@@ -246,13 +222,7 @@ describe("payReward", function () {
           await api3Token
             .connect(roles.user1)
             .approve(api3Pool.address, user1Stake);
-          await api3Pool
-            .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake,
-              roles.user1.address
-            );
+          await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
           // Fast forward time to one epoch into the future
           const genesisEpoch = await api3Pool.genesisEpoch();
           const genesisEpochPlusOne = genesisEpoch.add(
@@ -303,20 +273,8 @@ describe("payReward", function () {
         await api3Token
           .connect(roles.user2)
           .approve(api3Pool.address, user2Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+        await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
         // Fast forward time to one epoch into the future
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));
@@ -360,20 +318,8 @@ describe("payReward", function () {
         await api3Token
           .connect(roles.user2)
           .approve(api3Pool.address, user2Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+        await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
         // Fast forward time to five epochs into the future
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
@@ -434,20 +380,8 @@ describe("payReward", function () {
         await api3Token
           .connect(roles.user2)
           .approve(api3Pool.address, user2Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
-        await api3Pool
-          .connect(roles.user2)
-          .depositAndStake(
-            roles.user2.address,
-            user2Stake,
-            roles.user2.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+        await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
         // Fast forward time to five epochs into the future
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
@@ -490,12 +424,8 @@ describe("payReward", function () {
       await api3Token
         .connect(roles.user2)
         .approve(api3Pool.address, user2Stake);
-      await api3Pool
-        .connect(roles.user1)
-        .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
-      await api3Pool
-        .connect(roles.user2)
-        .depositAndStake(roles.user2.address, user2Stake, roles.user2.address);
+      await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+      await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
       // Fast forward time to one epoch into the future
       const genesisEpoch = await api3Pool.genesisEpoch();
       const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -44,10 +44,11 @@ describe("stake", function () {
         const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
         await api3Token
           .connect(roles.deployer)
+          .transfer(roles.user1.address, user1Stake);
+        await api3Token
+          .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.randomPerson)
-          .deposit(roles.deployer.address, user1Stake, roles.user1.address);
+        await api3Pool.connect(roles.user1).deposit(user1Stake);
         // Stake the first half
         await api3Pool
           .connect(roles.user1)
@@ -99,10 +100,11 @@ describe("stake", function () {
         const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
         await api3Token
           .connect(roles.deployer)
+          .transfer(roles.user1.address, user1Stake);
+        await api3Token
+          .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.randomPerson)
-          .deposit(roles.deployer.address, user1Stake, roles.user1.address);
+        await api3Pool.connect(roles.user1).deposit(user1Stake);
         await expect(api3Pool.connect(roles.user1).stake(user1Stake))
           .to.emit(api3Pool, "Staked")
           .withArgs(
@@ -130,37 +132,19 @@ describe("stake", function () {
 });
 
 describe("depositAndStake", function () {
-  context("Caller is the beneficiary", function () {
-    it("deposits and stakes", async function () {
-      const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-      await api3Token
-        .connect(roles.deployer)
-        .transfer(roles.user1.address, user1Stake);
-      await api3Token
-        .connect(roles.user1)
-        .approve(api3Pool.address, user1Stake);
-      await expect(
-        api3Pool
-          .connect(roles.user1)
-          .depositAndStake(roles.user1.address, user1Stake, roles.user1.address)
-      )
-        .to.emit(api3Pool, "Staked")
-        .withArgs(
-          roles.user1.address,
-          user1Stake,
-          user1Stake.add(ethers.BigNumber.from(1))
-        );
-    });
-  });
-  context("Caller is not the beneficiary", function () {
-    it("reverts", async function () {
-      const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-      await expect(
-        api3Pool
-          .connect(roles.randomPerson)
-          .depositAndStake(roles.user1.address, user1Stake, roles.user1.address)
-      ).to.be.revertedWith("Unauthorized");
-    });
+  it("deposits and stakes", async function () {
+    const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
+    await api3Token
+      .connect(roles.deployer)
+      .transfer(roles.user1.address, user1Stake);
+    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
+    await expect(api3Pool.connect(roles.user1).depositAndStake(user1Stake))
+      .to.emit(api3Pool, "Staked")
+      .withArgs(
+        roles.user1.address,
+        user1Stake,
+        user1Stake.add(ethers.BigNumber.from(1))
+      );
   });
 });
 
@@ -175,9 +159,7 @@ describe("scheduleUnstake", function () {
       await api3Token
         .connect(roles.user1)
         .approve(api3Pool.address, user1Stake);
-      await api3Pool
-        .connect(roles.user1)
-        .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+      await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
       const currentBlock = await ethers.provider.getBlock(
         await ethers.provider.getBlockNumber()
       );
@@ -217,13 +199,7 @@ describe("unstake", function () {
             await api3Token
               .connect(roles.user1)
               .approve(api3Pool.address, user1Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
+            await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
             // Have the user delegate
             await api3Pool
               .connect(roles.user1)
@@ -281,13 +257,7 @@ describe("unstake", function () {
             await api3Token
               .connect(roles.user1)
               .approve(api3Pool.address, user1Stake);
-            await api3Pool
-              .connect(roles.user1)
-              .depositAndStake(
-                roles.user1.address,
-                user1Stake,
-                roles.user1.address
-              );
+            await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
             // Schedule unstake
             await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
             // Fast forward time to one epoch into the future
@@ -328,13 +298,7 @@ describe("unstake", function () {
           await api3Token
             .connect(roles.user1)
             .approve(api3Pool.address, user1Stake);
-          await api3Pool
-            .connect(roles.user1)
-            .depositAndStake(
-              roles.user1.address,
-              user1Stake,
-              roles.user1.address
-            );
+          await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
           // Schedule unstake
           await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
           // Set the DAO Agent
@@ -401,13 +365,7 @@ describe("unstake", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
         // Schedule unstake
         await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
         // Fast forward time to one epoch into the future
@@ -439,13 +397,7 @@ describe("unstake", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool
-          .connect(roles.user1)
-          .depositAndStake(
-            roles.user1.address,
-            user1Stake,
-            roles.user1.address
-          );
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
         // Schedule unstake
         await api3Pool.connect(roles.user1).scheduleUnstake(user1Stake);
         // Attempt to unstake
@@ -469,9 +421,7 @@ describe("unstakeAndWithdraw", function () {
       .connect(roles.deployer)
       .transfer(roles.user1.address, user1Stake);
     await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
-    await api3Pool
-      .connect(roles.user1)
-      .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+    await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
     // Schedule unstake
     const user1Unstake = user1Stake.div(ethers.BigNumber.from(2));
     await api3Pool.connect(roles.user1).scheduleUnstake(user1Unstake);

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -48,7 +48,7 @@ describe("stake", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool.connect(roles.user1).deposit(user1Stake);
+        await api3Pool.connect(roles.user1).depositRegular(user1Stake);
         // Stake the first half
         await api3Pool
           .connect(roles.user1)
@@ -104,7 +104,7 @@ describe("stake", function () {
         await api3Token
           .connect(roles.user1)
           .approve(api3Pool.address, user1Stake);
-        await api3Pool.connect(roles.user1).deposit(user1Stake);
+        await api3Pool.connect(roles.user1).depositRegular(user1Stake);
         await expect(api3Pool.connect(roles.user1).stake(user1Stake))
           .to.emit(api3Pool, "Staked")
           .withArgs(

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -15,6 +15,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -29,7 +30,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
 });
 

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -46,11 +46,6 @@ describe("constructor", function () {
       expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
         ethers.BigNumber.from(52)
       );
-      // Max interaction frequency is 20
-      expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
-        ethers.BigNumber.from(20)
-      );
-
       // App addresses are not set
       expect(await api3Pool.agentAppPrimary()).to.equal(
         ethers.constants.AddressZero

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -14,6 +14,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -28,7 +29,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
 });
 
 describe("constructor", function () {

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -36,77 +36,90 @@ beforeEach(async () => {
 });
 
 describe("constructor", function () {
-  it("initializes with the correct parameters", async function () {
-    // Epoch length is 7 days in seconds
-    expect(await api3Pool.EPOCH_LENGTH()).to.equal(
-      ethers.BigNumber.from(7 * 24 * 60 * 60)
-    );
-    // Reward vesting period is 52 week = 1 year
-    expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
-      ethers.BigNumber.from(52)
-    );
-    // Max interaction frequency is 20
-    expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
-      ethers.BigNumber.from(20)
-    );
+  context("TimelockManager is valid", function () {
+    it("initializes with the correct parameters", async function () {
+      // Epoch length is 7 days in seconds
+      expect(await api3Pool.EPOCH_LENGTH()).to.equal(
+        ethers.BigNumber.from(7 * 24 * 60 * 60)
+      );
+      // Reward vesting period is 52 week = 1 year
+      expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
+        ethers.BigNumber.from(52)
+      );
+      // Max interaction frequency is 20
+      expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
+        ethers.BigNumber.from(20)
+      );
 
-    // App addresses are not set
-    expect(await api3Pool.agentAppPrimary()).to.equal(
-      ethers.constants.AddressZero
-    );
-    expect(await api3Pool.agentAppSecondary()).to.equal(
-      ethers.constants.AddressZero
-    );
-    expect(await api3Pool.votingAppPrimary()).to.equal(
-      ethers.constants.AddressZero
-    );
-    expect(await api3Pool.votingAppSecondary()).to.equal(
-      ethers.constants.AddressZero
-    );
-    // Claims manager statuses are false by default
-    expect(
-      await api3Pool.claimsManagerStatus(roles.randomPerson.address)
-    ).to.equal(false);
+      // App addresses are not set
+      expect(await api3Pool.agentAppPrimary()).to.equal(
+        ethers.constants.AddressZero
+      );
+      expect(await api3Pool.agentAppSecondary()).to.equal(
+        ethers.constants.AddressZero
+      );
+      expect(await api3Pool.votingAppPrimary()).to.equal(
+        ethers.constants.AddressZero
+      );
+      expect(await api3Pool.votingAppSecondary()).to.equal(
+        ethers.constants.AddressZero
+      );
+      // Claims manager statuses are false by default
+      expect(
+        await api3Pool.claimsManagerStatus(roles.randomPerson.address)
+      ).to.equal(false);
 
-    // Verify the default DAO parameters
-    expect(await api3Pool.stakeTarget()).to.equal(
-      ethers.BigNumber.from("50" + "000" + "000")
-    );
-    expect(await api3Pool.minApr()).to.equal(
-      ethers.BigNumber.from("2" + "500" + "000")
-    );
-    expect(await api3Pool.maxApr()).to.equal(
-      ethers.BigNumber.from("75" + "000" + "000")
-    );
-    expect(await api3Pool.aprUpdateCoefficient()).to.equal(
-      ethers.BigNumber.from("1" + "000" + "000")
-    );
-    expect(await api3Pool.unstakeWaitPeriod()).to.equal(
-      await api3Pool.EPOCH_LENGTH()
-    );
-    expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
-      ethers.BigNumber.from("100" + "000")
-    );
-    // Initialize the APR at max APR
-    expect(await api3Pool.currentApr()).to.equal(await api3Pool.maxApr());
+      // Verify the default DAO parameters
+      expect(await api3Pool.stakeTarget()).to.equal(
+        ethers.BigNumber.from("50" + "000" + "000")
+      );
+      expect(await api3Pool.minApr()).to.equal(
+        ethers.BigNumber.from("2" + "500" + "000")
+      );
+      expect(await api3Pool.maxApr()).to.equal(
+        ethers.BigNumber.from("75" + "000" + "000")
+      );
+      expect(await api3Pool.aprUpdateCoefficient()).to.equal(
+        ethers.BigNumber.from("1" + "000" + "000")
+      );
+      expect(await api3Pool.unstakeWaitPeriod()).to.equal(
+        await api3Pool.EPOCH_LENGTH()
+      );
+      expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
+        ethers.BigNumber.from("100" + "000")
+      );
+      // Initialize the APR at max APR
+      expect(await api3Pool.currentApr()).to.equal(await api3Pool.maxApr());
 
-    // Token address set correctly
-    expect(await api3Pool.api3Token()).to.equal(api3Token.address);
-    // Initialize share price at 1
-    expect(await api3Pool.totalSupply()).to.equal(ethers.BigNumber.from(1));
-    expect(await api3Pool.totalStake()).to.equal(ethers.BigNumber.from(1));
-    // Genesis epoch is the current epoch
-    const currentBlock = await ethers.provider.getBlock(
-      await ethers.provider.getBlockNumber()
-    );
-    const currentEpoch = ethers.BigNumber.from(currentBlock.timestamp).div(
-      await api3Pool.EPOCH_LENGTH()
-    );
-    expect(await api3Pool.genesisEpoch()).to.equal(currentEpoch);
-    // Skip the reward payment of the genesis epoch
-    expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-      await api3Pool.genesisEpoch()
-    );
+      // Token address set correctly
+      expect(await api3Pool.api3Token()).to.equal(api3Token.address);
+      // Initialize share price at 1
+      expect(await api3Pool.totalSupply()).to.equal(ethers.BigNumber.from(1));
+      expect(await api3Pool.totalStake()).to.equal(ethers.BigNumber.from(1));
+      // Genesis epoch is the current epoch
+      const currentBlock = await ethers.provider.getBlock(
+        await ethers.provider.getBlockNumber()
+      );
+      const currentEpoch = ethers.BigNumber.from(currentBlock.timestamp).div(
+        await api3Pool.EPOCH_LENGTH()
+      );
+      expect(await api3Pool.genesisEpoch()).to.equal(currentEpoch);
+      // Skip the reward payment of the genesis epoch
+      expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
+        await api3Pool.genesisEpoch()
+      );
+    });
+  });
+  context("TimelockManager is invalid", function () {
+    it("reverts", async function () {
+      const api3PoolFactory = await ethers.getContractFactory(
+        "Api3Pool",
+        roles.deployer
+      );
+      await expect(
+        api3PoolFactory.deploy(api3Token.address, ethers.constants.AddressZero)
+      ).to.be.revertedWith("Invalid TimelockManager");
+    });
   });
 });
 

--- a/packages/pool/test/TimelockUtils.sol.js
+++ b/packages/pool/test/TimelockUtils.sol.js
@@ -30,54 +30,80 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
 });
 
 describe("depositWithVesting", function () {
-  context("User has not received from this timelock manager", function () {
-    context("Release end is later than release start", function () {
-      context("Amount is not zero", function () {
-        it("deposits with vesting", async function () {
-          const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.mockTimelockManager.address, depositAmount);
-          const currentBlock = await ethers.provider.getBlock(
-            await ethers.provider.getBlockNumber()
-          );
-          const releaseStart = currentBlock.timestamp - 100;
-          const releaseEnd = currentBlock.timestamp + 100;
-          await api3Token
-            .connect(roles.mockTimelockManager)
-            .approve(api3Pool.address, depositAmount);
-          await expect(
-            api3Pool
+  context("Caller is the timelock manager", function () {
+    context("User does not have an active timelock", function () {
+      context("Release end is later than release start", function () {
+        context("Amount is not zero", function () {
+          it("deposits with vesting", async function () {
+            const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
+            await api3Token
+              .connect(roles.deployer)
+              .transfer(roles.mockTimelockManager.address, depositAmount);
+            const currentBlock = await ethers.provider.getBlock(
+              await ethers.provider.getBlockNumber()
+            );
+            const releaseStart = currentBlock.timestamp - 100;
+            const releaseEnd = currentBlock.timestamp + 100;
+            await api3Token
               .connect(roles.mockTimelockManager)
-              .depositWithVesting(
-                roles.mockTimelockManager.address,
-                depositAmount,
+              .approve(api3Pool.address, depositAmount);
+            await expect(
+              api3Pool
+                .connect(roles.mockTimelockManager)
+                .depositWithVesting(
+                  roles.mockTimelockManager.address,
+                  depositAmount,
+                  roles.user1.address,
+                  releaseStart,
+                  releaseEnd
+                )
+            )
+              .to.emit(api3Pool, "DepositedVesting")
+              .withArgs(
                 roles.user1.address,
+                depositAmount,
                 releaseStart,
                 releaseEnd
-              )
-          )
-            .to.emit(api3Pool, "DepositedVesting")
-            .withArgs(
-              roles.user1.address,
-              depositAmount,
-              releaseStart,
-              releaseEnd
+              );
+          });
+        });
+        context("Amount is zero", function () {
+          it("reverts", async function () {
+            const depositAmount = ethers.BigNumber.from(0);
+            const currentBlock = await ethers.provider.getBlock(
+              await ethers.provider.getBlockNumber()
             );
+            const releaseStart = currentBlock.timestamp - 100;
+            const releaseEnd = currentBlock.timestamp + 100;
+            await expect(
+              api3Pool
+                .connect(roles.mockTimelockManager)
+                .depositWithVesting(
+                  roles.mockTimelockManager.address,
+                  depositAmount,
+                  roles.user1.address,
+                  releaseStart,
+                  releaseEnd
+                )
+            ).to.be.revertedWith("Invalid value");
+          });
         });
       });
-      context("Amount is zero", function () {
+      context("Release end is not later than release start", function () {
         it("reverts", async function () {
-          const depositAmount = ethers.BigNumber.from(0);
+          const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
           const currentBlock = await ethers.provider.getBlock(
             await ethers.provider.getBlockNumber()
           );
-          const releaseStart = currentBlock.timestamp - 100;
-          const releaseEnd = currentBlock.timestamp + 100;
+          const releaseStart = currentBlock.timestamp + 100;
+          const releaseEnd = currentBlock.timestamp - 100;
           await expect(
             api3Pool
               .connect(roles.mockTimelockManager)
@@ -92,14 +118,29 @@ describe("depositWithVesting", function () {
         });
       });
     });
-    context("Release end is not later than release start", function () {
+    context("User has an active timelock", function () {
       it("reverts", async function () {
         const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
+        await api3Token
+          .connect(roles.deployer)
+          .transfer(roles.mockTimelockManager.address, depositAmount);
         const currentBlock = await ethers.provider.getBlock(
           await ethers.provider.getBlockNumber()
         );
-        const releaseStart = currentBlock.timestamp + 100;
-        const releaseEnd = currentBlock.timestamp - 100;
+        const releaseStart = currentBlock.timestamp - 100;
+        const releaseEnd = currentBlock.timestamp + 100;
+        await api3Token
+          .connect(roles.mockTimelockManager)
+          .approve(api3Pool.address, depositAmount);
+        await api3Pool
+          .connect(roles.mockTimelockManager)
+          .depositWithVesting(
+            roles.mockTimelockManager.address,
+            depositAmount,
+            roles.user1.address,
+            releaseStart,
+            releaseEnd
+          );
         await expect(
           api3Pool
             .connect(roles.mockTimelockManager)
@@ -110,11 +151,11 @@ describe("depositWithVesting", function () {
               releaseStart,
               releaseEnd
             )
-        ).to.be.revertedWith("Invalid value");
+        ).to.be.revertedWith("Unauthorized");
       });
     });
   });
-  context("User has received from this timelock manager before", function () {
+  context("Caller is not the timelock manager", function () {
     it("reverts", async function () {
       const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
       await api3Token
@@ -128,18 +169,9 @@ describe("depositWithVesting", function () {
       await api3Token
         .connect(roles.mockTimelockManager)
         .approve(api3Pool.address, depositAmount);
-      await api3Pool
-        .connect(roles.mockTimelockManager)
-        .depositWithVesting(
-          roles.mockTimelockManager.address,
-          depositAmount,
-          roles.user1.address,
-          releaseStart,
-          releaseEnd
-        );
       await expect(
         api3Pool
-          .connect(roles.mockTimelockManager)
+          .connect(roles.randomPerson)
           .depositWithVesting(
             roles.mockTimelockManager.address,
             depositAmount,
@@ -147,7 +179,7 @@ describe("depositWithVesting", function () {
             releaseStart,
             releaseEnd
           )
-      ).to.be.revertedWith("Unauthorized");
+      ).to.be.revertedWith("Caller not TimelockManager");
     });
   });
 });
@@ -181,17 +213,10 @@ describe("updateTimelockStatus", function () {
           await expect(
             api3Pool
               .connect(roles.randomPerson)
-              .updateTimelockStatus(
-                roles.user1.address,
-                roles.mockTimelockManager.address
-              )
+              .updateTimelockStatus(roles.user1.address)
           )
             .to.emit(api3Pool, "UpdatedTimelock")
-            .withArgs(
-              roles.user1.address,
-              roles.mockTimelockManager.address,
-              ethers.BigNumber.from(0)
-            );
+            .withArgs(roles.user1.address, ethers.BigNumber.from(0));
         });
       });
       context("It is not past release end", function () {
@@ -221,17 +246,10 @@ describe("updateTimelockStatus", function () {
           await expect(
             api3Pool
               .connect(roles.randomPerson)
-              .updateTimelockStatus(
-                roles.user1.address,
-                roles.mockTimelockManager.address
-              )
+              .updateTimelockStatus(roles.user1.address)
           )
             .to.emit(api3Pool, "UpdatedTimelock")
-            .withArgs(
-              roles.user1.address,
-              roles.mockTimelockManager.address,
-              depositAmount.div(2)
-            );
+            .withArgs(roles.user1.address, depositAmount.div(2));
         });
       });
     });
@@ -260,17 +278,11 @@ describe("updateTimelockStatus", function () {
           );
         await api3Pool
           .connect(roles.randomPerson)
-          .updateTimelockStatus(
-            roles.user1.address,
-            roles.mockTimelockManager.address
-          );
+          .updateTimelockStatus(roles.user1.address);
         await expect(
           api3Pool
             .connect(roles.randomPerson)
-            .updateTimelockStatus(
-              roles.user1.address,
-              roles.mockTimelockManager.address
-            )
+            .updateTimelockStatus(roles.user1.address)
         ).to.be.revertedWith("Unauthorized");
       });
     });
@@ -301,10 +313,7 @@ describe("updateTimelockStatus", function () {
       await expect(
         api3Pool
           .connect(roles.randomPerson)
-          .updateTimelockStatus(
-            roles.user1.address,
-            roles.mockTimelockManager.address
-          )
+          .updateTimelockStatus(roles.user1.address)
       ).to.be.revertedWith("Unauthorized");
     });
   });

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -46,7 +46,7 @@ describe("deposit", function () {
     await api3Token
       .connect(roles.user1)
       .approve(api3Pool.address, user1Deposit);
-    await expect(api3Pool.connect(roles.user1).deposit(user1Deposit))
+    await expect(api3Pool.connect(roles.user1).depositRegular(user1Deposit))
       .to.emit(api3Pool, "Deposited")
       .withArgs(roles.user1.address, user1Deposit);
     const user = await api3Pool.users(roles.user1.address);
@@ -92,7 +92,9 @@ describe("withdraw", function () {
         await api3Pool.callStatic.getUserLocked(roles.user1.address)
       );
       await expect(
-        api3Pool.connect(roles.user1).withdraw(roles.user1.address, unlocked)
+        api3Pool
+          .connect(roles.user1)
+          .withdrawRegular(roles.user1.address, unlocked)
       )
         .to.emit(api3Pool, "Withdrawn")
         .withArgs(roles.user1.address, roles.user1.address, unlocked);
@@ -115,7 +117,7 @@ describe("withdraw", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdraw(roles.user1.address, ethers.BigNumber.from(1))
+          .withdrawRegular(roles.user1.address, ethers.BigNumber.from(1))
       ).to.be.revertedWith("Invalid value");
     });
   });
@@ -124,7 +126,7 @@ describe("withdraw", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdraw(roles.user1.address, ethers.BigNumber.from(1))
+          .withdrawRegular(roles.user1.address, ethers.BigNumber.from(1))
       ).to.be.revertedWith("Invalid value");
     });
   });

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -133,7 +133,7 @@ describe("withdrawRegular", function () {
   });
 });
 
-describe("calculateUserLockedIteratively", function () {
+describe("precalculateUserLocked", function () {
   context("Iteration window is not zero", function () {
     context("User has staked at some point", function () {
       context("Call does not finish the calculation", function () {
@@ -167,7 +167,7 @@ describe("calculateUserLockedIteratively", function () {
             await expect(
               api3Pool
                 .connect(roles.user1)
-                .calculateUserLockedIteratively(
+                .precalculateUserLocked(
                   roles.user1.address,
                   ethers.BigNumber.from(
                     noEpochsToCalculateLockedForAtEachIteration
@@ -193,7 +193,7 @@ describe("calculateUserLockedIteratively", function () {
           await expect(
             api3Pool
               .connect(roles.user1)
-              .calculateUserLockedIteratively(
+              .precalculateUserLocked(
                 roles.user1.address,
                 ethers.BigNumber.from(
                   noEpochsToCalculateLockedForAtEachIteration
@@ -210,7 +210,7 @@ describe("calculateUserLockedIteratively", function () {
         await expect(
           api3Pool
             .connect(roles.user1)
-            .calculateUserLockedIteratively(
+            .precalculateUserLocked(
               roles.user1.address,
               ethers.BigNumber.from(10)
             )
@@ -223,7 +223,7 @@ describe("calculateUserLockedIteratively", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .calculateUserLockedIteratively(
+          .precalculateUserLocked(
             roles.user1.address,
             ethers.BigNumber.from(0)
           )
@@ -232,7 +232,7 @@ describe("calculateUserLockedIteratively", function () {
   });
 });
 
-describe("withdrawWithPrecalculatedLocked", function () {
+describe("withdrawPrecalculated", function () {
   context("Locked amount is precalculated", function () {
     it("withdraws", async function () {
       // Authorize pool contract to mint tokens
@@ -268,14 +268,14 @@ describe("withdrawWithPrecalculatedLocked", function () {
       await api3Pool.connect(roles.user1).unstake();
       await api3Pool
         .connect(roles.user1)
-        .calculateUserLockedIteratively(
+        .precalculateUserLocked(
           roles.user1.address,
           ethers.BigNumber.from(100)
         );
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdrawWithPrecalculatedLocked(roles.user1.address, user1Stake)
+          .withdrawPrecalculated(roles.user1.address, user1Stake)
       )
         .to.emit(api3Pool, "Withdrawn")
         .withArgs(roles.user1.address, roles.user1.address, user1Stake);
@@ -286,7 +286,7 @@ describe("withdrawWithPrecalculatedLocked", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdrawWithPrecalculatedLocked(
+          .withdrawPrecalculated(
             roles.user1.address,
             ethers.BigNumber.from(1)
           )

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -42,12 +42,11 @@ describe("deposit", function () {
     const user1Deposit = ethers.utils.parseEther("20" + "000" + "000");
     await api3Token
       .connect(roles.deployer)
+      .transfer(roles.user1.address, user1Deposit);
+    await api3Token
+      .connect(roles.user1)
       .approve(api3Pool.address, user1Deposit);
-    await expect(
-      api3Pool
-        .connect(roles.randomPerson)
-        .deposit(roles.deployer.address, user1Deposit, roles.user1.address)
-    )
+    await expect(api3Pool.connect(roles.user1).deposit(user1Deposit))
       .to.emit(api3Pool, "Deposited")
       .withArgs(roles.user1.address, user1Deposit);
     const user = await api3Pool.users(roles.user1.address);
@@ -70,9 +69,7 @@ describe("withdraw", function () {
       await api3Token
         .connect(roles.user1)
         .approve(api3Pool.address, user1Stake);
-      await api3Pool
-        .connect(roles.user1)
-        .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+      await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
       // Fast forward 100 epochs to have some rewards paid out and unlocked
       const genesisEpoch = await api3Pool.genesisEpoch();
       for (let i = 0; i < 100; i++) {
@@ -114,9 +111,7 @@ describe("withdraw", function () {
       await api3Token
         .connect(roles.user1)
         .approve(api3Pool.address, user1Stake);
-      await api3Pool
-        .connect(roles.user1)
-        .depositAndStake(roles.user1.address, user1Stake, roles.user1.address);
+      await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
       await expect(
         api3Pool
           .connect(roles.user1)

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -15,6 +15,7 @@ beforeEach(async () => {
     claimsManager: accounts[5],
     user1: accounts[6],
     user2: accounts[7],
+    mockTimelockManager: accounts[8],
     randomPerson: accounts[9],
   };
   const api3TokenFactory = await ethers.getContractFactory(
@@ -29,7 +30,10 @@ beforeEach(async () => {
     "Api3Pool",
     roles.deployer
   );
-  api3Pool = await api3PoolFactory.deploy(api3Token.address);
+  api3Pool = await api3PoolFactory.deploy(
+    api3Token.address,
+    roles.mockTimelockManager.address
+  );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
 });
 


### PR DESCRIPTION
All linear searches are replaced with binary searches except `getUserLocked()` because for the majority of the users (which will stake once and remain staked for a long duration) the current implementation is extremely more gas-efficient compared to the alternatives. However, the current implementation disables users from withdrawing if they have made a lot of staking updates in the last year (more than 50 per week according to tests). As a solution, an additional `withdrawWithPrecalculatedLocked()` method is implemented to allow such users to withdraw their funds by making multiple transactions (note that we don't consider this as normal user flow, it's a fail-safe).
This makes `MAX_INTERACTION_FREQUENCY` unnecessary, which is why it's removed.
Finally, delegate address checkpoint array is kept in a naive way (doesn't overwrite if there hasn't been a new proposal) to simplify the implementation, as the binary search allows this (and users can't update delegates frequently anyway so this wasn't providing any benefits assuming there is going to be at least a proposal a week, which means delegate checkpoints wouldn't have been overwritten anyway).