### PR TITLE
[QSP-3] Replace linear searches with binary searches

### DIFF
--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -113,15 +113,6 @@ This array will be searched linearly while calling `balanceOfAt()` to vote (for 
 In case the user bloats this array on purpose by repeatedly staking 1 (Wei) API3, they may manage to lock themselves out of voting/withdrawing.
 Since this will only happen voluntarily and will get resolved automatically simply by not staking/unstaking for a while, it is not considered as an issue.
 
-## Over-population of `user.delegatedTo` and the interaction frequency limit
-
-Each time a user is delegated to/undelegated from, their `user.delegatedTo` will be updated.
-Furthermore, if there has been a proposal made since the last update, a new element will be added to the `Checkpoint` array.
-This array will be searched linearly when the delegated user calls `balanceOfAt()` to vote (for the last week).
-A concern here is that too many interleaved proposals and delegation updates may bloat the user's `delegatedTo` array for the last week and prevent them from voting.
-To prevent this from being used as an attack vector, a transaction cannot add more than `MAX_INTERACTION_FREQUENCY` (default value = `20`) elements to a user's `delegatedTo` in a week.
-The proposal spam protection mechanisms are expected to keep the number of proposals in a week well below `20` (and if they cannot, their parameters should be updated to reduce spam further).
-
 ## Double Agent and Api3Voting apps
 
 The DAO will have two pairs of Agents and Api3Voting apps, where having an Agent app make a transaction will require a proposal to be passed with the respective Api3Voting app.

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -49,10 +49,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             userReceivedDelegation(delegate) + userShares
             );
         // Record the new delegate for the user
-        updateAddressCheckpointArray(
-            user.delegates,
-            delegate
-            );
+        user.delegates.push(AddressCheckpoint({
+            fromBlock: block.number,
+            _address: delegate
+            }));
         emit Delegated(
             msg.sender,
             delegate
@@ -79,10 +79,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             delegate.delegatedTo,
             userReceivedDelegation(userDelegate) - userShares
             );
-        updateAddressCheckpointArray(
-            user.delegates,
-            address(0)
-            );
+        user.delegates.push(AddressCheckpoint({
+            fromBlock: block.number,
+            _address: address(0)
+            }));
         user.lastDelegationUpdateTimestamp = block.timestamp;
         emit Undelegated(
             msg.sender,

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -227,7 +227,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         Checkpoint[] storage checkpoints,
         uint256 _block
         )
-        private
+        internal
         view
         returns(uint256)
     {

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -72,8 +72,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the pool shares of a user at a specific block
-    /// @dev Starts from the most recent value in `user.shares` and searches
-    /// backwards one element at a time
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Pool shares of the user at the block
@@ -86,7 +84,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        return getValueAt(users[userAddress].shares, _block, 0);
+        return getValueAtWithBinarySearch(users[userAddress].shares, _block);
     }
 
     /// @notice Called to get the current pool shares of a user
@@ -99,49 +97,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns(uint256)
     {
         return userSharesAt(userAddress, block.number);
-    }
-
-    /// @notice Called to get the pool shares of a user at a specific block
-    /// using binary search
-    /// @dev From 
-    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
-    /// This method is not used by the current iteration of the DAO/pool and is
-    /// implemented for future external contracts to use to get the user shares
-    /// at an arbitrary block.
-    /// @param userAddress User address
-    /// @param _block Block number for which the query is being made for
-    /// @return Pool shares of the user at the block
-    function userSharesAtWithBinarySearch(
-        address userAddress,
-        uint256 _block
-        )
-        external
-        view
-        override
-        returns(uint256)
-    {
-        Checkpoint[] storage checkpoints = users[userAddress].shares;
-        if (checkpoints.length == 0)
-            return 0;
-
-        // Shortcut for the actual value
-        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
-            return checkpoints[checkpoints.length - 1].value;
-        if (_block < checkpoints[0].fromBlock)
-            return 0;
-
-        // Binary search of the value in the array
-        uint min = 0;
-        uint max = checkpoints.length - 1;
-        while (max > min) {
-            uint mid = (max + min + 1) / 2;
-            if (checkpoints[mid].fromBlock <= _block) {
-                min = mid;
-            } else {
-                max = mid - 1;
-            }
-        }
-        return checkpoints[min].value;
     }
 
     /// @notice Called to get the current staked tokens of the user
@@ -158,11 +113,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
 
     /// @notice Called to get the voting power delegated to a user at a
     /// specific block
-    /// @dev Starts from the most recent value in `user.delegatedTo` and
-    /// searches backwards one element at a time. If `_block` is within
-    /// `EPOCH_LENGTH`, this call is guaranteed to find the value among
-    /// the last `MAX_INTERACTION_FREQUENCY` elements, which is why it only
-    /// searches through them. 
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Voting power delegated to the user at the block
@@ -175,11 +125,10 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(uint256)
     {
-        Checkpoint[] storage delegatedTo = users[userAddress].delegatedTo;
-        uint256 minimumCheckpointIndex = delegatedTo.length > MAX_INTERACTION_FREQUENCY
-            ? delegatedTo.length - MAX_INTERACTION_FREQUENCY
-            : 0;
-        return getValueAt(delegatedTo, _block, minimumCheckpointIndex);
+        return getValueAtWithBinarySearch(
+            users[userAddress].delegatedTo,
+            _block
+            );
     }
 
     /// @notice Called to get the current voting power delegated to a user
@@ -195,11 +144,6 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the delegate of the user at a specific block
-    /// @dev Starts from the most recent value in `user.delegates` and
-    /// searches backwards one element at a time. If `_block` is within
-    /// `EPOCH_LENGTH`, this call is guaranteed to find the value among
-    /// the last 2 elements because a user cannot update delegate more
-    /// frequently than once an `EPOCH_LENGTH`.
     /// @param userAddress User address
     /// @param _block Block number
     /// @return Delegate of the user at the specific block
@@ -212,15 +156,10 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         override
         returns(address)
     {
-        AddressCheckpoint[] storage delegates = users[userAddress].delegates;
-        for (uint256 i = delegates.length; i > 0; i--)
-        {
-            if (delegates[i - 1].fromBlock <= _block)
-            {
-                return delegates[i - 1]._address;
-            }
-        }
-        return address(0);
+        return getAddressAtWithBinarySearch(
+            users[userAddress].delegates,
+            _block
+            );
     }
 
     /// @notice Called to get the current delegate of the user
@@ -278,30 +217,78 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     }
 
     /// @notice Called to get the value of a checkpoint array at a specific
-    /// block
+    /// block using binary search
+    /// @dev Adapted from 
+    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
     /// @param checkpoints Checkpoints array
     /// @param _block Block number for which the query is being made
     /// @return Value of the checkpoint array at the block
-    function getValueAt(
+    function getValueAtWithBinarySearch(
         Checkpoint[] storage checkpoints,
-        uint256 _block,
-        uint256 minimumCheckpointIndex
+        uint256 _block
         )
-        internal
+        private
         view
         returns(uint256)
     {
-        uint256 i = checkpoints.length;
-        for (; i > minimumCheckpointIndex; i--)
-        {
-            if (checkpoints[i - 1].fromBlock <= _block)
-            {
-                return checkpoints[i - 1].value;
+        if (checkpoints.length == 0)
+            return 0;
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
+            return checkpoints[checkpoints.length - 1].value;
+        if (_block < checkpoints[0].fromBlock)
+            return 0;
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length - 1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock <= _block) {
+                min = mid;
+            } else {
+                max = mid - 1;
             }
         }
-        // Revert if the value being searched for comes before
-        // `minimumCheckpointIndex`
-        require(i == 0, ERROR_VALUE);
-        return 0;
+        return checkpoints[min].value;
+    }
+
+    /// @notice Called to get the value of an address-checkpoint array at a
+    /// specific block using binary search
+    /// @dev Adapted from 
+    /// https://github.com/aragon/minime/blob/1d5251fc88eee5024ff318d95bc9f4c5de130430/contracts/MiniMeToken.sol#L431
+    /// @param checkpoints Address-checkpoint array
+    /// @param _block Block number for which the query is being made
+    /// @return Value of the address-checkpoint array at the block
+    function getAddressAtWithBinarySearch(
+        AddressCheckpoint[] storage checkpoints,
+        uint256 _block
+        )
+        private
+        view
+        returns(address)
+    {
+        if (checkpoints.length == 0)
+            return address(0);
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length -1].fromBlock)
+            return checkpoints[checkpoints.length - 1]._address;
+        if (_block < checkpoints[0].fromBlock)
+            return address(0);
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length - 1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock <= _block) {
+                min = mid;
+            } else {
+                max = mid - 1;
+            }
+        }
+        return checkpoints[min]._address;
     }
 }

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -526,37 +526,4 @@ contract StateUtils is IStateUtils {
             }
         }
     }
-
-    /// @notice Called internally to update an address checkpoint array
-    /// @param addressCheckpointArray Address checkpoint array to be updated
-    /// @param _address Address to be updated with
-    function updateAddressCheckpointArray(
-        AddressCheckpoint[] storage addressCheckpointArray,
-        address _address
-        )
-        internal
-    {
-        if (addressCheckpointArray.length == 0)
-        {
-            addressCheckpointArray.push(AddressCheckpoint({
-                fromBlock: lastVoteSnapshotBlock,
-                _address: _address
-                }));
-        }
-        else
-        {
-            AddressCheckpoint storage lastElement = addressCheckpointArray[addressCheckpointArray.length - 1];
-            if (lastElement.fromBlock < lastVoteSnapshotBlock)
-            {
-                addressCheckpointArray.push(AddressCheckpoint({
-                    fromBlock: lastVoteSnapshotBlock,
-                    _address: _address
-                    }));
-            }
-            else
-            {
-                lastElement._address = _address;
-            }
-        }
-    }
 }

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -36,7 +36,6 @@ contract StateUtils is IStateUtils {
     struct LockedCalculationState {
         uint256 initialIndEpoch;
         uint256 nextIndEpoch;
-        uint256 nextIndUserShares;
         uint256 locked;
     }
 

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -33,6 +33,14 @@ contract StateUtils is IStateUtils {
         uint256 unstakeAmount;
     }
 
+    struct LockedCalculationState {
+        uint256 initialIndEpoch;
+        uint256 initialUserSharesLength;
+        uint256 nextIndEpoch;
+        uint256 nextIndUserShares;
+        uint256 locked;
+    }
+
     /// @notice Length of the epoch in which the staking reward is paid out
     /// once. It is hardcoded as 7 days in seconds.
     /// @dev In addition to regulating reward payments, this variable is used
@@ -104,6 +112,7 @@ contract StateUtils is IStateUtils {
 
     /// @notice User records
     mapping(address => User) public users;
+    mapping(address => LockedCalculationState) internal userToLockedCalculationState;
 
     /// @notice Total number of tokens staked at the pool
     uint256 public totalStake;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -35,7 +35,6 @@ contract StateUtils is IStateUtils {
 
     struct LockedCalculationState {
         uint256 initialIndEpoch;
-        uint256 initialUserSharesLength;
         uint256 nextIndEpoch;
         uint256 nextIndUserShares;
         uint256 locked;

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -70,15 +70,10 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         require(userSharesLength != 0, "User never had shares");
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[userAddress];
-        // Reset the state if the epoch has passed or the user has updated
-        // their staking status
-        if (
-            state.initialIndEpoch != currentEpoch
-                || state.initialUserSharesLength != userSharesLength
-            )
+        // Reset the state if there was no calculation made in this epoch
+        if (state.initialIndEpoch != currentEpoch)
         {
             state.initialIndEpoch = currentEpoch;
-            state.initialUserSharesLength = userSharesLength;
             state.nextIndEpoch = currentEpoch;
             state.nextIndUserShares = userSharesLength - 1;
             state.locked = 0;
@@ -140,11 +135,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         payReward();
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[msg.sender];
-        require(
-            state.initialIndEpoch == currentEpoch 
-                && state.initialUserSharesLength == users[msg.sender].shares.length,
-            "Locked amount not precalculated"
-            );
+        require(state.initialIndEpoch == currentEpoch, "Locked amount not precalculated");
         withdraw(destination, amount, state.locked);
     }
 

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -55,7 +55,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     /// @param userAddress User address
     /// @param noEpochsPerIteration Number of epochs per iteration
     /// @return finished Calculation has finished in this call
-    function calculateUserLockedIteratively(
+    function precalculateUserLocked(
         address userAddress,
         uint256 noEpochsPerIteration
         )
@@ -109,12 +109,12 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
     }
 
     /// @notice Called by the user to withdraw after their locked token amount
-    /// is calculated with repeated calls to `calculateUserLockedIteratively()`
-    /// @dev Only use `calculateUserLockedIteratively()` and this method if
+    /// is calculated with repeated calls to `precalculateUserLocked()`
+    /// @dev Only use `precalculateUserLocked()` and this method if
     /// `withdrawRegular()` hits the block gas limit
     /// @param destination Token transfer destination
     /// @param amount Amount to be withdrawn
-    function withdrawWithPrecalculatedLocked(
+    function withdrawPrecalculated(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -40,14 +40,6 @@ interface IGetterUtils is IStateUtils {
         view
         returns(uint256);
 
-    function userSharesAtWithBinarySearch(
-        address userAddress,
-        uint256 _block
-        )
-        external
-        view
-        returns(uint256);
-
     function userStake(address userAddress)
         external
         view

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -15,10 +15,34 @@ interface ITransferUtils is IDelegationUtils{
         uint256 amount
         );
 
+    event CalculatingUserLocked(
+        address indexed user,
+        uint256 nextIndEpoch,
+        uint256 oldestLockedEpoch
+        );
+
+    event CalculatedUserLocked(
+        address indexed user,
+        uint256 amount
+        );
+
     function depositRegular(uint256 amount)
         external;
 
     function withdrawRegular(
+        address destination,
+        uint256 amount
+        )
+        external;
+
+    function calculateUserLockedIteratively(
+        address userAddress,
+        uint256 noEpochsPerIteration
+        )
+        external
+        returns (bool finished);
+
+    function withdrawWithPrecalculatedLocked(
         address destination,
         uint256 amount
         )

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -35,14 +35,14 @@ interface ITransferUtils is IDelegationUtils{
         )
         external;
 
-    function calculateUserLockedIteratively(
+    function precalculateUserLocked(
         address userAddress,
         uint256 noEpochsPerIteration
         )
         external
         returns (bool finished);
 
-    function withdrawWithPrecalculatedLocked(
+    function withdrawPrecalculated(
         address destination,
         uint256 amount
         )

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -58,69 +58,63 @@ describe("delegateVotingPower", function () {
           "User has not updated their delegation status less than reward epoch ago",
           function () {
             context("User did not have the same delegate", function () {
-                  it("delegates voting power", async function () {
-                    // Have two users stake
-                    const user1Stake = ethers.utils.parseEther(
-                      "20" + "000" + "000"
-                    );
-                    const user2Stake = ethers.utils.parseEther(
-                      "60" + "000" + "000"
-                    );
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(roles.user1.address, user1Stake);
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(roles.user2.address, user2Stake);
-                    await api3Token
-                      .connect(roles.user1)
-                      .approve(api3Pool.address, user1Stake);
-                    await api3Token
-                      .connect(roles.user2)
-                      .approve(api3Pool.address, user2Stake);
-                    await api3Pool
-                      .connect(roles.user1)
-                      .depositAndStake(user1Stake);
-                    await api3Pool
-                      .connect(roles.user2)
-                      .depositAndStake(user2Stake);
-                    // Have user 1 delegate to someone else first
-                    await api3Pool
-                      .connect(roles.user1)
-                      .delegateVotingPower(roles.randomPerson.address);
-                    expect(
-                      await api3Pool.balanceOf(roles.user1.address)
-                    ).to.equal(ethers.BigNumber.from(0));
-                    expect(
-                      await api3Pool.balanceOf(roles.randomPerson.address)
-                    ).to.equal(user1Stake);
-                    // Fast forward time
-                    await ethers.provider.send("evm_increaseTime", [
-                      EPOCH_LENGTH.toNumber(),
-                    ]);
-                    // ... then have user 1 delegate to user 2
-                    await expect(
-                      api3Pool
-                        .connect(roles.user1)
-                        .delegateVotingPower(roles.user2.address)
-                    )
-                      .to.emit(api3Pool, "Delegated")
-                      .withArgs(roles.user1.address, roles.user2.address);
-                    expect(
-                      await api3Pool.balanceOf(roles.user1.address)
-                    ).to.equal(ethers.BigNumber.from(0));
-                    expect(
-                      await api3Pool.balanceOf(roles.user2.address)
-                    ).to.equal(user2Stake.add(user1Stake));
-                    expect(
-                      await api3Pool.userReceivedDelegation(roles.user2.address)
-                    ).to.equal(user1Stake);
-                    expect(
-                      await api3Pool.userDelegate(roles.user1.address)
-                    ).to.equal(roles.user2.address);
-                  });
-                
-              
+              it("delegates voting power", async function () {
+                // Have two users stake
+                const user1Stake = ethers.utils.parseEther(
+                  "20" + "000" + "000"
+                );
+                const user2Stake = ethers.utils.parseEther(
+                  "60" + "000" + "000"
+                );
+                await api3Token
+                  .connect(roles.deployer)
+                  .transfer(roles.user1.address, user1Stake);
+                await api3Token
+                  .connect(roles.deployer)
+                  .transfer(roles.user2.address, user2Stake);
+                await api3Token
+                  .connect(roles.user1)
+                  .approve(api3Pool.address, user1Stake);
+                await api3Token
+                  .connect(roles.user2)
+                  .approve(api3Pool.address, user2Stake);
+                await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+                await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
+                // Have user 1 delegate to someone else first
+                await api3Pool
+                  .connect(roles.user1)
+                  .delegateVotingPower(roles.randomPerson.address);
+                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
+                  ethers.BigNumber.from(0)
+                );
+                expect(
+                  await api3Pool.balanceOf(roles.randomPerson.address)
+                ).to.equal(user1Stake);
+                // Fast forward time
+                await ethers.provider.send("evm_increaseTime", [
+                  EPOCH_LENGTH.toNumber(),
+                ]);
+                // ... then have user 1 delegate to user 2
+                await expect(
+                  api3Pool
+                    .connect(roles.user1)
+                    .delegateVotingPower(roles.user2.address)
+                )
+                  .to.emit(api3Pool, "Delegated")
+                  .withArgs(roles.user1.address, roles.user2.address);
+                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
+                  ethers.BigNumber.from(0)
+                );
+                expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
+                  user2Stake.add(user1Stake)
+                );
+                expect(
+                  await api3Pool.userReceivedDelegation(roles.user2.address)
+                ).to.equal(user1Stake);
+                expect(
+                  await api3Pool.userDelegate(roles.user1.address)
+                ).to.equal(roles.user2.address);
+              });
             });
             context("User had the same delegate", function () {
               it("reverts", async function () {

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting;
-let EPOCH_LENGTH, MAX_INTERACTION_FREQUENCY;
+let EPOCH_LENGTH;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -48,7 +48,6 @@ beforeEach(async () => {
       roles.votingAppSecondary.address
     );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
-  MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
 describe("delegateVotingPower", function () {
@@ -59,9 +58,6 @@ describe("delegateVotingPower", function () {
           "User has not updated their delegation status less than reward epoch ago",
           function () {
             context("User did not have the same delegate", function () {
-              context(
-                "Receiving user has not been delegated to too frequently",
-                function () {
                   it("delegates voting power", async function () {
                     // Have two users stake
                     const user1Stake = ethers.utils.parseEther(
@@ -123,66 +119,8 @@ describe("delegateVotingPower", function () {
                       await api3Pool.userDelegate(roles.user1.address)
                     ).to.equal(roles.user2.address);
                   });
-                }
-              );
-              context(
-                "Receiving user has been delegated to too frequently",
-                function () {
-                  it("reverts", async function () {
-                    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-                      const randomWallet = ethers.Wallet.createRandom().connect(
-                        ethers.provider
-                      );
-                      await roles.deployer.sendTransaction({
-                        to: randomWallet.address,
-                        value: ethers.utils.parseEther("1"),
-                      });
-                      const amount = ethers.BigNumber.from(1000);
-                      await api3Token
-                        .connect(roles.deployer)
-                        .transfer(randomWallet.address, amount);
-                      await api3Token
-                        .connect(randomWallet)
-                        .approve(api3Pool.address, amount, {
-                          gasLimit: 500000,
-                        });
-                      await api3Pool
-                        .connect(randomWallet)
-                        .depositAndStake(amount, { gasLimit: 500000 });
-                      await api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        });
-                      await api3Voting.newVote();
-                    }
-                    const randomWallet = ethers.Wallet.createRandom().connect(
-                      ethers.provider
-                    );
-                    await roles.deployer.sendTransaction({
-                      to: randomWallet.address,
-                      value: ethers.utils.parseEther("1"),
-                    });
-                    const amount = ethers.BigNumber.from(1000);
-                    await api3Token
-                      .connect(roles.deployer)
-                      .transfer(randomWallet.address, amount);
-                    await api3Token
-                      .connect(randomWallet)
-                      .approve(api3Pool.address, amount, { gasLimit: 500000 });
-                    await api3Pool
-                      .connect(randomWallet)
-                      .depositAndStake(amount, { gasLimit: 500000 });
-                    await expect(
-                      api3Pool
-                        .connect(randomWallet)
-                        .delegateVotingPower(roles.user1.address, {
-                          gasLimit: 500000,
-                        })
-                    ).to.be.revertedWith("Try again a week later");
-                  });
-                }
-              );
+                
+              
             });
             context("User had the same delegate", function () {
               it("reverts", async function () {

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -153,29 +153,26 @@ describe("userReceivedDelegationAt", function () {
 
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
-    await api3Voting.newVote();
-    const firstBlockNumber = await ethers.provider.getBlockNumber();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
-    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
-      ethers.constants.AddressZero
-    );
+    const firstBlockNumber = await ethers.provider.getBlockNumber();
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
-    await api3Voting.newVote();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.randomPerson.address);
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
-    await api3Voting.newVote();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     // Check delegates
+    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
+      ethers.constants.AddressZero
+    );
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber)
     ).to.equal(roles.user2.address);
@@ -184,9 +181,6 @@ describe("getDelegateAt", function () {
     ).to.equal(roles.randomPerson.address);
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber + 2)
-    ).to.equal(roles.randomPerson.address);
-    expect(
-      await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber + 3)
     ).to.equal(roles.user2.address);
   });
 });

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -109,156 +109,58 @@ describe("userSharesAt", function () {
   });
 });
 
-describe("userSharesAtWithBinarySearch", function () {
-  it("gets user shares at", async function () {
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(roles.user1.address, 0)
-    ).to.equal(ethers.BigNumber.from(0));
-    const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-    await api3Token
-      .connect(roles.deployer)
-      .transfer(roles.user1.address, user1Stake);
-    await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
-    await api3Pool.connect(roles.user1).depositRegular(user1Stake);
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    await api3Pool.connect(roles.user1).stake(ethers.BigNumber.from(1));
-    const currentBlockNumber = await ethers.provider.getBlockNumber();
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber
-      )
-    ).to.equal(ethers.BigNumber.from(3));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 1
-      )
-    ).to.equal(ethers.BigNumber.from(2));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 2
-      )
-    ).to.equal(ethers.BigNumber.from(1));
-    expect(
-      await api3Pool.userSharesAtWithBinarySearch(
-        roles.user1.address,
-        currentBlockNumber - 3
-      )
-    ).to.equal(ethers.BigNumber.from(0));
-  });
-});
-
 describe("userReceivedDelegationAt", function () {
-  context("Searched block is within MAX_INTERACTION_FREQUENCY", function () {
-    it("gets user's received delegation at the block", async function () {
-      const genesisEpoch = await api3Pool.genesisEpoch();
-      const amount = ethers.BigNumber.from(1000);
-      const delegationBlocks = [];
-      for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-        await api3Voting.newVote();
-        delegationBlocks.push(await ethers.provider.getBlockNumber());
-        const randomWallet = ethers.Wallet.createRandom().connect(
-          ethers.provider
-        );
-        await roles.deployer.sendTransaction({
-          to: randomWallet.address,
-          value: ethers.utils.parseEther("1"),
-        });
-        await api3Token
-          .connect(roles.deployer)
-          .transfer(randomWallet.address, amount);
-        await api3Token
-          .connect(randomWallet)
-          .approve(api3Pool.address, amount, { gasLimit: 500000 });
-        await api3Pool.connect(randomWallet).depositAndStake(amount, {
-          gasLimit: 500000,
-        });
-        await api3Pool
-          .connect(randomWallet)
-          .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
-        await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
-        ]);
-      }
-      for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
-        expect(
-          await api3Pool.userReceivedDelegationAt(
-            roles.user1.address,
-            delegationBlocks[i]
-          )
-        ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
-      }
-    });
-  });
-  context(
-    "Searched block is not within MAX_INTERACTION_FREQUENCY",
-    function () {
-      it("reverts", async function () {
-        const genesisEpoch = await api3Pool.genesisEpoch();
-        const amount = ethers.BigNumber.from(1000);
-        const delegationBlocks = [];
-        for (
-          let i = 0;
-          i < MAX_INTERACTION_FREQUENCY.add(ethers.BigNumber.from(1));
-          i++
-        ) {
-          await api3Voting.newVote();
-          delegationBlocks.push(await ethers.provider.getBlockNumber());
-          const randomWallet = ethers.Wallet.createRandom().connect(
-            ethers.provider
-          );
-          await roles.deployer.sendTransaction({
-            to: randomWallet.address,
-            value: ethers.utils.parseEther("1"),
-          });
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(randomWallet.address, amount);
-          await api3Token
-            .connect(randomWallet)
-            .approve(api3Pool.address, amount, { gasLimit: 500000 });
-          await api3Pool
-            .connect(randomWallet)
-            .depositAndStake(amount, { gasLimit: 500000 });
-          await api3Pool
-            .connect(randomWallet)
-            .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
-          await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
-          ]);
-        }
-        for (
-          let i = 1;
-          i < MAX_INTERACTION_FREQUENCY.add(ethers.BigNumber.from(1));
-          i++
-        ) {
-          expect(
-            await api3Pool.userReceivedDelegationAt(
-              roles.user1.address,
-              delegationBlocks[i]
-            )
-          ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
-        }
-        await expect(
-          api3Pool.userReceivedDelegationAt(
-            roles.user1.address,
-            delegationBlocks[0]
-          )
-        ).to.be.revertedWith("Invalid value");
+  it("gets user's received delegation at the block", async function () {
+    const genesisEpoch = await api3Pool.genesisEpoch();
+    const amount = ethers.BigNumber.from(1000);
+    const delegationBlocks = [];
+    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+      await api3Voting.newVote();
+      delegationBlocks.push(await ethers.provider.getBlockNumber());
+      const randomWallet = ethers.Wallet.createRandom().connect(
+        ethers.provider
+      );
+      await roles.deployer.sendTransaction({
+        to: randomWallet.address,
+        value: ethers.utils.parseEther("1"),
       });
+      await api3Token
+        .connect(roles.deployer)
+        .transfer(randomWallet.address, amount);
+      await api3Token
+        .connect(randomWallet)
+        .approve(api3Pool.address, amount, { gasLimit: 500000 });
+      await api3Pool.connect(randomWallet).depositAndStake(amount, {
+        gasLimit: 500000,
+      });
+      await api3Pool
+        .connect(randomWallet)
+        .delegateVotingPower(roles.user1.address, { gasLimit: 500000 });
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
+      ]);
     }
-  );
+    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+      expect(
+        await api3Pool.userReceivedDelegationAt(
+          roles.user1.address,
+          delegationBlocks[i]
+        )
+      ).to.equal(amount.mul(ethers.BigNumber.from(i + 1)));
+    }
+  });
 });
 
 describe("getDelegateAt", function () {
   it("gets delegate at", async function () {
+    await api3Voting.newVote();
     const firstBlockNumber = await ethers.provider.getBlockNumber();
     await api3Pool
       .connect(roles.user1)
       .delegateVotingPower(roles.user2.address);
+    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
+      ethers.constants.AddressZero
+    );
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     await api3Voting.newVote();
@@ -274,9 +176,6 @@ describe("getDelegateAt", function () {
     // Fast forward time
     await ethers.provider.send("evm_increaseTime", [EPOCH_LENGTH.toNumber()]);
     // Check delegates
-    expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
-      roles.user2.address
-    );
     expect(
       await api3Pool.userDelegateAt(roles.user1.address, firstBlockNumber)
     ).to.equal(roles.user2.address);

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -4,7 +4,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting, api3Staker;
-let EPOCH_LENGTH, REWARD_VESTING_PERIOD, MAX_INTERACTION_FREQUENCY;
+let EPOCH_LENGTH, REWARD_VESTING_PERIOD;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -59,7 +59,6 @@ beforeEach(async () => {
   );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
   REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
-  MAX_INTERACTION_FREQUENCY = await api3Pool.MAX_INTERACTION_FREQUENCY();
 });
 
 describe("totalSupplyOneBlockAgo", function () {
@@ -113,8 +112,9 @@ describe("userReceivedDelegationAt", function () {
   it("gets user's received delegation at the block", async function () {
     const genesisEpoch = await api3Pool.genesisEpoch();
     const amount = ethers.BigNumber.from(1000);
+    const noDelegations = 20;
     const delegationBlocks = [];
-    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+    for (let i = 0; i < noDelegations; i++) {
       await api3Voting.newVote();
       delegationBlocks.push(await ethers.provider.getBlockNumber());
       const randomWallet = ethers.Wallet.createRandom().connect(
@@ -140,7 +140,7 @@ describe("userReceivedDelegationAt", function () {
         genesisEpoch.add(i).add(1).mul(EPOCH_LENGTH).toNumber(),
       ]);
     }
-    for (let i = 0; i < MAX_INTERACTION_FREQUENCY; i++) {
+    for (let i = 0; i < noDelegations; i++) {
       expect(
         await api3Pool.userReceivedDelegationAt(
           roles.user1.address,

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -46,11 +46,6 @@ describe("constructor", function () {
       expect(await api3Pool.REWARD_VESTING_PERIOD()).to.equal(
         ethers.BigNumber.from(52)
       );
-      // Max interaction frequency is 20
-      expect(await api3Pool.MAX_INTERACTION_FREQUENCY()).to.equal(
-        ethers.BigNumber.from(20)
-      );
-
       // App addresses are not set
       expect(await api3Pool.agentAppPrimary()).to.equal(
         ethers.constants.AddressZero

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -133,7 +133,7 @@ describe("withdrawRegular", function () {
   });
 });
 
-describe("calculateUserLockedIteratively", function () {
+describe("precalculateUserLocked", function () {
   context("Iteration window is not zero", function () {
     context("User has staked at some point", function () {
       context("Call does not finish the calculation", function () {
@@ -167,7 +167,7 @@ describe("calculateUserLockedIteratively", function () {
             await expect(
               api3Pool
                 .connect(roles.user1)
-                .calculateUserLockedIteratively(
+                .precalculateUserLocked(
                   roles.user1.address,
                   ethers.BigNumber.from(
                     noEpochsToCalculateLockedForAtEachIteration
@@ -193,7 +193,7 @@ describe("calculateUserLockedIteratively", function () {
           await expect(
             api3Pool
               .connect(roles.user1)
-              .calculateUserLockedIteratively(
+              .precalculateUserLocked(
                 roles.user1.address,
                 ethers.BigNumber.from(
                   noEpochsToCalculateLockedForAtEachIteration
@@ -210,7 +210,7 @@ describe("calculateUserLockedIteratively", function () {
         await expect(
           api3Pool
             .connect(roles.user1)
-            .calculateUserLockedIteratively(
+            .precalculateUserLocked(
               roles.user1.address,
               ethers.BigNumber.from(10)
             )
@@ -223,7 +223,7 @@ describe("calculateUserLockedIteratively", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .calculateUserLockedIteratively(
+          .precalculateUserLocked(
             roles.user1.address,
             ethers.BigNumber.from(0)
           )
@@ -232,7 +232,7 @@ describe("calculateUserLockedIteratively", function () {
   });
 });
 
-describe("withdrawWithPrecalculatedLocked", function () {
+describe("withdrawPrecalculated", function () {
   context("Locked amount is precalculated", function () {
     it("withdraws", async function () {
       // Authorize pool contract to mint tokens
@@ -268,14 +268,14 @@ describe("withdrawWithPrecalculatedLocked", function () {
       await api3Pool.connect(roles.user1).unstake();
       await api3Pool
         .connect(roles.user1)
-        .calculateUserLockedIteratively(
+        .precalculateUserLocked(
           roles.user1.address,
           ethers.BigNumber.from(100)
         );
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdrawWithPrecalculatedLocked(roles.user1.address, user1Stake)
+          .withdrawPrecalculated(roles.user1.address, user1Stake)
       )
         .to.emit(api3Pool, "Withdrawn")
         .withArgs(roles.user1.address, roles.user1.address, user1Stake);
@@ -286,7 +286,7 @@ describe("withdrawWithPrecalculatedLocked", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdrawWithPrecalculatedLocked(
+          .withdrawPrecalculated(
             roles.user1.address,
             ethers.BigNumber.from(1)
           )


### PR DESCRIPTION
All linear searches are replaced with binary searches except `getUserLocked()` because for the majority of the users (which will stake once and remain staked for a long duration) the current implementation is extremely more gas-efficient compared to the alternatives. However, the current implementation disables users from withdrawing if they have made a lot of staking updates in the last year (more than 50 per week according to tests). As a solution, an additional `withdrawPrecalculated()` method is implemented to allow such users to withdraw their funds by making multiple transactions (note that we don't consider this as normal user flow, it's a fail-safe).
This makes `MAX_INTERACTION_FREQUENCY` unnecessary, which is why it's removed.
Finally, delegate address checkpoint array is kept in a naive way (doesn't overwrite if there hasn't been a new proposal) to simplify the implementation, as the binary search allows this (and users can't update delegates frequently anyway so this wasn't providing any benefits assuming there is going to be at least a proposal a week, which means delegate checkpoints wouldn't have been overwritten anyway).