### PR TITLE
[QSP-4] Prevent griefing through delegation

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -54,7 +54,6 @@ contract Api3Voting is IForwarder, AragonApp {
     uint64 public voteTime;
 
     IApi3Pool public api3Pool;
-    mapping (address => uint256) private userAddressToLastNewProposalTimestamp;
 
     // We are mimicing an array, we use a mapping instead to make app upgrade more graceful
     mapping (uint256 => Vote) internal votes;
@@ -257,8 +256,9 @@ contract Api3Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
-        require(userAddressToLastNewProposalTimestamp[msg.sender].add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
-        userAddressToLastNewProposalTimestamp[msg.sender] = now;
+        (, , , , , uint256 mostRecentProposalTimestamp) = api3Pool.getUser(msg.sender);
+        require(mostRecentProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
+        api3Pool.updateMostRecentProposalTimestamp(msg.sender);
 
         uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
 

--- a/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
+++ b/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
@@ -27,4 +27,19 @@ interface IApi3Pool {
 
     function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
         external;
+
+    function updateMostRecentProposalTimestamp(address userAddress)
+        external;
+
+    function getUser(address userAddress)
+        external
+        view
+        returns(
+            uint256 unstaked,
+            uint256 vesting,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 unstakeScheduledFor,
+            uint256 unstakeAmount,
+            uint256 mostRecentProposalTimestamp
+            );
 }

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -76,4 +76,29 @@ contract Api3TokenMock is MiniMeToken {
     {
         return false;
     }
+
+    function getUser(address userAddress)
+        external
+        view
+        returns(
+            uint256 unstaked,
+            uint256 vesting,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 unstakeScheduledFor,
+            uint256 unstakeAmount,
+            uint256 mostRecentProposalTimestamp
+            )
+    {
+        unstaked = 0;
+        vesting = 0;
+        lastDelegationUpdateTimestamp = 0;
+        unstakeScheduledFor = 0;
+        unstakeAmount = 0;
+        mostRecentProposalTimestamp = 0;
+    }
+
+    function updateMostRecentProposalTimestamp(address userAddress)
+        external
+    {
+    }
 }

--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -106,13 +106,6 @@ API3 tokens allocated to founding members, builders and investors are timelocked
 The beneficiaries of the timelocked tokens can withdraw their tokens to this pool contract, where the vesting schedule will be continued.
 The tokens withdrawn to the pool will be able to be staked by their owners to receive voting power, staking rewards and be used as collateral.
 
-## Over-population of `user.shares`
-
-Each time a user stakes/unstakes, an additional element will be added to their `user.shares` `Checkpoint` array.
-This array will be searched linearly while calling `balanceOfAt()` to vote (for the last week) and `getUserLocked()` to withdraw (for the last year).
-In case the user bloats this array on purpose by repeatedly staking 1 (Wei) API3, they may manage to lock themselves out of voting/withdrawing.
-Since this will only happen voluntarily and will get resolved automatically simply by not staking/unstaking for a while, it is not considered as an issue.
-
 ## Double Agent and Api3Voting apps
 
 The DAO will have two pairs of Agents and Api3Voting apps, where having an Agent app make a transaction will require a proposal to be passed with the respective Api3Voting app.
@@ -120,14 +113,6 @@ The quorum requirements for the primary Api3Voting app will be high, and primary
 The quorum requirements for the secondary Api3Voting app will be low, and the secondary Agent app will be used for more day-to-day proposals (set stake target parameters, give grants).
 
 The Agent apps are authorized to update respective DAO parameters, and Api3Voting apps are authorized to mark the creation of a new proposal, which signals this contract to create a new checkpoint for the related records.
-Note that primary and secondary proposal cooldowns are kept separately, which means that a user can make two proposals in less than 7 days, as long as one is done through the primary Api3Voting app and the other is done through the secondary Api3Voting app.
-This is implemented as such to avoid unnecessary complexity.
-
-## Binary search-able `user.shares`
-
-`user.shares` at specific blocks are accessible through `userSharesAtWithBinarySearch()` by doing a binary search.
-This method is not used internally in the pool contract, but is planned to be used by future contract implementations that may require to recall how much users have staked at a specific point in time.
-Concerns about `user.shares` growing to unsearchable sizes are not within the scope of this contract's implementation as it does not depend on this method.
 
 ## Skipped rewards
 

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -113,6 +113,15 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
 
     /// @notice Called to get the voting power delegated to a user at a
     /// specific block
+    /// @dev Since the minimum `proposalVotingPowerThreshold` is 0.1%, if the
+    /// the voting apps are Api3Voting.sol (which should be the case) there can
+    /// be at most 100/0.1=1000 proposals made in the last `EPOCH_LENGTH`.
+    /// `user.delegatedTo` checkpoints get overwritten if a new proposal was
+    /// not made since the last update and `getValueAtWithBinarySearch()`
+    /// limits the search to the last 1024 elements if possible, which means
+    /// that while calling this method, if `_block` is within the current
+    /// `EPOCH_LENGTH` (i.e., if the call is for an open vote), the method will
+    /// have a deterministic upper boundary for the gas cost.
     /// @param userAddress User address
     /// @param _block Block number for which the query is being made for
     /// @return Voting power delegated to the user at the block

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -225,6 +225,38 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         }
     }
 
+    /// @notice Called to get the details of a user
+    /// @param userAddress User address
+    /// @return unstaked Amount of unstaked API3 tokens
+    /// @return vesting Amount of API3 tokens locked by vesting
+    /// @return lastDelegationUpdateTimestamp Time of most recent delegation
+    /// update
+    /// @return unstakeScheduledFor Time unstaking is scheduled for
+    /// @return unstakeAmount Amount scheduled to unstake
+    /// @return mostRecentProposalTimestamp Time when the user made their most
+    /// recent proposal
+    function getUser(address userAddress)
+        external
+        view
+        override
+        returns(
+            uint256 unstaked,
+            uint256 vesting,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 unstakeScheduledFor,
+            uint256 unstakeAmount,
+            uint256 mostRecentProposalTimestamp
+            )
+    {
+        User storage user = users[userAddress];
+        unstaked = user.unstaked;
+        vesting = user.vesting;
+        lastDelegationUpdateTimestamp = user.lastDelegationUpdateTimestamp;
+        unstakeScheduledFor = user.unstakeScheduledFor;
+        unstakeAmount = user.unstakeAmount;
+        mostRecentProposalTimestamp = user.mostRecentProposalTimestamp;
+    }
+
     /// @notice Called to get the value of a checkpoint array at a specific
     /// block using binary search
     /// @dev Adapted from 

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -240,8 +240,22 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         if (_block < checkpoints[0].fromBlock)
             return 0;
 
+        // Limit the search to the last 1024 elements if the value being
+        // searched falls within that window
+        uint min;
+        if (
+            checkpoints.length > 1024
+                && checkpoints[checkpoints.length - 1024].fromBlock < _block
+            )
+        {
+            min = checkpoints.length - 1024;
+        }
+        else
+        {
+            min = 0;
+        }
+
         // Binary search of the value in the array
-        uint min = 0;
         uint max = checkpoints.length - 1;
         while (max > min) {
             uint mid = (max + min + 1) / 2;
@@ -278,8 +292,22 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         if (_block < checkpoints[0].fromBlock)
             return address(0);
 
+        // Limit the search to the last 1024 elements if the value being
+        // searched falls within that window
+        uint min;
+        if (
+            checkpoints.length > 1024
+                && checkpoints[checkpoints.length - 1024].fromBlock < _block
+            )
+        {
+            min = checkpoints.length - 1024;
+        }
+        else
+        {
+            min = 0;
+        }
+
         // Binary search of the value in the array
-        uint min = 0;
         uint max = checkpoints.length - 1;
         while (max > min) {
             uint mid = (max + min + 1) / 2;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -193,6 +193,15 @@ contract StateUtils is IStateUtils {
         _;
     }
 
+    /// @dev Reverts if the caller is not an API3 DAO Api3Voting app
+    modifier onlyVotingApp() {
+        require(
+            msg.sender == votingAppPrimary || msg.sender == votingAppSecondary,
+            ERROR_UNAUTHORIZED
+            );
+        _;
+    }
+
     /// @param api3TokenAddress API3 token contract address
     constructor(
         address api3TokenAddress,
@@ -419,11 +428,8 @@ contract StateUtils is IStateUtils {
     function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
         external
         override
+        onlyVotingApp()
     {
-        require(
-            msg.sender == votingAppPrimary || msg.sender == votingAppSecondary,
-            ERROR_UNAUTHORIZED
-            );
         lastVoteSnapshotBlock = snapshotBlock;
         emit UpdatedLastVoteSnapshotBlock(
             msg.sender,

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -31,6 +31,7 @@ contract StateUtils is IStateUtils {
         uint256 lastDelegationUpdateTimestamp;
         uint256 unstakeScheduledFor;
         uint256 unstakeAmount;
+        uint256 mostRecentProposalTimestamp;
     }
 
     struct LockedCalculationState {
@@ -434,6 +435,22 @@ contract StateUtils is IStateUtils {
         emit UpdatedLastVoteSnapshotBlock(
             msg.sender,
             snapshotBlock,
+            block.timestamp
+            );
+    }
+
+    /// @notice Called by a DAO Api3Voting app at proposal creation-time to
+    /// update the timestamp of the user's most recent proposal
+    /// @param userAddress User address
+    function updateMostRecentProposalTimestamp(address userAddress)
+        external
+        override
+        onlyVotingApp()
+    {
+        users[userAddress].mostRecentProposalTimestamp = block.timestamp;
+        emit UpdatedMostRecentProposalTimestamp(
+            msg.sender,
+            userAddress,
             block.timestamp
             );
     }

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -379,7 +379,8 @@ contract StateUtils is IStateUtils {
         onlyAgentAppPrimary()
     {
         require(
-            _proposalVotingPowerThreshold <= 10 * ONE_PERCENT,
+            _proposalVotingPowerThreshold >= ONE_PERCENT / 10
+                && _proposalVotingPowerThreshold <= 10 * ONE_PERCENT,
             ERROR_VALUE);
         uint256 oldProposalVotingPowerThreshold = proposalVotingPowerThreshold;
         proposalVotingPowerThreshold = _proposalVotingPowerThreshold;

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -75,4 +75,16 @@ interface IGetterUtils is IStateUtils {
         external
         view
         returns(uint256);
+
+    function getUser(address userAddress)
+        external
+        view
+        returns(
+            uint256 unstaked,
+            uint256 vesting,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 unstakeScheduledFor,
+            uint256 unstakeAmount,
+            uint256 mostRecentProposalTimestamp
+            );
 }

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -57,6 +57,12 @@ interface IStateUtils {
         uint256 lastVoteSnapshotBlockUpdateTimestamp
         );
 
+    event UpdatedMostRecentProposalTimestamp(
+        address votingApp,
+        address userAddress,
+        uint256 mostRecentProposalTimestamp
+        );
+
     function setDaoApps(
         address _agentAppPrimary,
         address _agentAppSecondary,
@@ -97,5 +103,8 @@ interface IStateUtils {
         external;
 
     function updateLastVoteSnapshotBlock(uint256 snapshotBlock)
+        external;
+
+    function updateMostRecentProposalTimestamp(address userAddress)
         external;
 }

--- a/packages/pool/contracts/mock/MockApi3Voting.sol
+++ b/packages/pool/contracts/mock/MockApi3Voting.sol
@@ -11,9 +11,10 @@ contract MockApi3Voting {
         api3Pool = IApi3Pool(_api3Pool);
     }
 
-    function newVote()
+    function newVote(address userAddress)
         external
     {
         api3Pool.updateLastVoteSnapshotBlock(block.number - 1);
+        api3Pool.updateMostRecentProposalTimestamp(userAddress);
     }
 }

--- a/packages/pool/hardhat.config.js
+++ b/packages/pool/hardhat.config.js
@@ -15,6 +15,9 @@ module.exports = {
     outputFile: "gas_report",
     noColors: true,
   },
+  mocha: {
+    timeout: 60000
+  },
   networks: {
     mainnet: {
       url: credentials.mainnet.providerUrl || "",

--- a/packages/pool/hardhat.config.js
+++ b/packages/pool/hardhat.config.js
@@ -16,7 +16,7 @@ module.exports = {
     noColors: true,
   },
   mocha: {
-    timeout: 60000
+    timeout: 60000,
   },
   networks: {
     mainnet: {

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -664,7 +664,7 @@ describe("setAprUpdateCoefficient", function () {
 describe("setProposalVotingPowerThreshold", function () {
   context("Caller is primary DAO Agent", function () {
     context(
-      "Proposal voting power threshold to be set is smaller than or equal to 10,000,000",
+      "Proposal voting power threshold to be set is between 100,000 (0.1%) and 10,000,000 (10%)",
       function () {
         it("sets proposal voting power threshold", async function () {
           await api3Pool
@@ -676,27 +676,47 @@ describe("setProposalVotingPowerThreshold", function () {
               roles.votingAppSecondary.address
             );
           const oldProposalVotingPowerThreshold = await api3Pool.proposalVotingPowerThreshold();
-          const newProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "1" + "000" + "000"
+          const firstNewProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "10" + "000" + "000"
           );
           await expect(
             api3Pool
               .connect(roles.agentAppPrimary)
-              .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+              .setProposalVotingPowerThreshold(
+                firstNewProposalVotingPowerThreshold
+              )
           )
             .to.emit(api3Pool, "SetProposalVotingPowerThreshold")
             .withArgs(
               oldProposalVotingPowerThreshold,
-              newProposalVotingPowerThreshold
+              firstNewProposalVotingPowerThreshold
             );
           expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
-            newProposalVotingPowerThreshold
+            firstNewProposalVotingPowerThreshold
+          );
+          const secondNewProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "100" + "000"
+          );
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setProposalVotingPowerThreshold(
+                secondNewProposalVotingPowerThreshold
+              )
+          )
+            .to.emit(api3Pool, "SetProposalVotingPowerThreshold")
+            .withArgs(
+              firstNewProposalVotingPowerThreshold,
+              secondNewProposalVotingPowerThreshold
+            );
+          expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
+            secondNewProposalVotingPowerThreshold
           );
         });
       }
     );
     context(
-      "Proposal voting power threshold to be set is larger than 10,000,000",
+      "Proposal voting power threshold to be set is not between 100,000 (0.1%) and 10,000,000 (10%)",
       function () {
         it("reverts", async function () {
           await api3Pool
@@ -707,13 +727,25 @@ describe("setProposalVotingPowerThreshold", function () {
               roles.votingAppPrimary.address,
               roles.votingAppSecondary.address
             );
-          const newProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "50" + "000" + "000"
-          );
+          const firstNewProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "10" + "000" + "000"
+          ).add(ethers.BigNumber.from(1));
           await expect(
             api3Pool
               .connect(roles.agentAppPrimary)
-              .setProposalVotingPowerThreshold(newProposalVotingPowerThreshold)
+              .setProposalVotingPowerThreshold(
+                firstNewProposalVotingPowerThreshold
+              )
+          ).to.be.revertedWith("Invalid value");
+          const secondNewProposalVotingPowerThreshold = ethers.BigNumber.from(
+            "100" + "000"
+          ).sub(ethers.BigNumber.from(1));
+          await expect(
+            api3Pool
+              .connect(roles.agentAppPrimary)
+              .setProposalVotingPowerThreshold(
+                secondNewProposalVotingPowerThreshold
+              )
           ).to.be.revertedWith("Invalid value");
         });
       }

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -223,10 +223,7 @@ describe("precalculateUserLocked", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .precalculateUserLocked(
-            roles.user1.address,
-            ethers.BigNumber.from(0)
-          )
+          .precalculateUserLocked(roles.user1.address, ethers.BigNumber.from(0))
       ).to.be.revertedWith("Iteration window invalid");
     });
   });
@@ -286,10 +283,7 @@ describe("withdrawPrecalculated", function () {
       await expect(
         api3Pool
           .connect(roles.user1)
-          .withdrawPrecalculated(
-            roles.user1.address,
-            ethers.BigNumber.from(1)
-          )
+          .withdrawPrecalculated(roles.user1.address, ethers.BigNumber.from(1))
       ).to.be.revertedWith("Locked amount not precalculated");
     });
   });


### PR DESCRIPTION
The griefing scenario described in QSP-4 has already been resolved in https://github.com/api3dao/api3-dao/pull/250 by replacing the linear searches with binary searches and removing `MAX_INTERACTION_FREQUENCY`. However, a similar scenario remains: A user repeatedly delegates to user, bloating their `user.delegatedTo` and permanently increasing their voting gas cost. 

Even though this attack is probably prohibitively costly, a solution is implemented in this PR at almost no cost:
- While applying binary search, if the value being searched is within the last 1024 elements, limit the search to these elements (2^10=1024, roughly corresponds to 10 storage reads)
- Set a 0.1% lower limit to `proposalVotingPowerThreshold`
- Keep the proposal timestamps for the users at the pool contract instead of the Api3Voting contracts so that each user can create one proposal per `EPOCH_LENGTH` instead of two (one at each voting app)

This means that there will be at most 100/0.1=1000 proposals during the previous week (which is only theoretical and highly unlikely) and since a new element is added to `user.delegatedTo` only after a new proposal (otherwise the last value gets overwritten), when a user wants to vote for an active proposal, the `user.delegatedTo` value that their transaction will search for will be within the last 1000 elements. Since the binary search implementation introduced in this PR will then search for the value within the last 1024 elements, this means that bloating the user's `user.delegatedTo` by griefing will no longer have a significant effect.