### PR TITLE
[QSP-9] Provide docs to verify publications/deployments

### DIFF
--- a/packages/dao/README.md
+++ b/packages/dao/README.md
@@ -17,46 +17,40 @@ npm run test
 
 **This needs to be repeated with the final mainnet deployment.**
 
-1. Install aragonCLI globally (specifying the package version because the current one seems to be broken for some machines):
+1. Install aragonCLI globally (specifying the package version because latest seems to be broken for some machines):
 ```sh
 npm install -g @aragon/cli@7.0.4
 ```
 
 2. Install [Frame](https://frame.sh/).
-Run it and make sure that it's connected to the correct chain.
+Run it and make sure that it is connected to the correct chain.
 
 3. Inspect the DAO with the following
 ```sh
 aragon dao apps <DAO kernel address> --use-frame
 ```
 For example, you can use `0x825cc178f0510de72c8d3af4be69917935b3d269` on Rinkeby (**note that this may not be identical to the final version**).
-Verify that the displayed information is correct.
+Review the displayed information is correct.
 
-4. Verify that the ACL (Access Control List) is configured correctly
-```sh
-aragon dao acl <DAO kernel address> --use-frame
-```
-
-5. In (3), you should have seen Api3Voting apps with the ID `0x323c4eb511f386e7972d45b948cc546db35e9ccc7161c056fb07e09abd87e554`.
+4. In (3), you should have seen Api3Voting apps with the ID `0x323c4eb511f386e7972d45b948cc546db35e9ccc7161c056fb07e09abd87e554`.
 This is derived as `namehash("api3voting.open.aragonpm.eth")`.
 To verify, run the following script
 ```sh
 npm run derive-namehash
 ```
 
-6. Set your Ethereum provider RPC URL in `~/.aragon/<network>_key.json` as below (this will connect to Frame so make sure that the correct chain is selected on it)
-```json
-{
-  "rpc": "http://127.0.0.1:1248"
-}
-```
+5. The Api3Voting apps will have a proxy address each.
+Read the contract address they are pointing at using `implementation()` (you can use Etherscan for this because the code of the proxy contract will be verified).
+Then check the source code at this implementation address using Etherscan and verify that it is identical to `Api3Voting.sol`.
 
-7. Check the contract address using the Aragon Package Manager
+6. Verify that the ACL (Access Control List) is configured correctly
 ```sh
-aragon apm versions api3voting.open.aragonpm.eth --environment rinkeby
+aragon dao acl <DAO kernel address> --use-frame
 ```
 
-8. Check the contract code on Etherscan
+7. Check that the following values are initialized correctly
+- `api3Pool` and the voting parameters (`supportRequiredPct` and `minAcceptQuorumPct`) at the Api3Voting apps
+- `api3Token`, `timelockManager`, `agentAppPrimary`, `agentAppSecondary`, `votingAppPrimary` and `votingAppSecondary` at the pool contract
 
 ## Permissions
 

--- a/packages/dao/README.md
+++ b/packages/dao/README.md
@@ -13,6 +13,50 @@ If solc gives `RangeError: Maximum call stack size exceeded`, use Node v8 or the
 npm run test
 ```
 
+## Verifying the DAO deployment
+
+**This needs to be repeated with the final mainnet deployment.**
+
+1. Install aragonCLI globally (specifying the package version because the current one seems to be broken for some machines):
+```sh
+npm install -g @aragon/cli@7.0.4
+```
+
+2. Install [Frame](https://frame.sh/).
+Run it and make sure that it's connected to the correct chain.
+
+3. Inspect the DAO with the following
+```sh
+aragon dao apps <DAO kernel address> --use-frame
+```
+For example, you can use `0x825cc178f0510de72c8d3af4be69917935b3d269` on Rinkeby (**note that this may not be identical to the final version**).
+Verify that the displayed information is correct.
+
+4. Verify that the ACL (Access Control List) is configured correctly
+```sh
+aragon dao acl <DAO kernel address> --use-frame
+```
+
+5. In (3), you should have seen Api3Voting apps with the ID `0x323c4eb511f386e7972d45b948cc546db35e9ccc7161c056fb07e09abd87e554`.
+This is derived as `namehash("api3voting.open.aragonpm.eth")`.
+To verify, run the following script
+```sh
+npm run derive-namehash
+```
+
+6. Set your Ethereum provider RPC URL in `~/.aragon/<network>_key.json` as below (this will connect to Frame so make sure that the correct chain is selected on it)
+```json
+{
+  "rpc": "http://127.0.0.1:1248"
+}
+```
+
+7. Check the contract address using the Aragon Package Manager
+```sh
+aragon apm versions api3voting.open.aragonpm.eth --environment rinkeby
+```
+
+8. Check the contract code on Etherscan
 
 ## Permissions
 

--- a/packages/dao/contracts/Api3Template.sol
+++ b/packages/dao/contracts/Api3Template.sol
@@ -5,9 +5,14 @@ import "@aragon/templates-shared/contracts/BaseTemplate.sol";
 import "@api3-dao/api3-voting/contracts/Api3Voting.sol";
 
 contract Api3Template is BaseTemplate {
-//    Comment below is ID for Rinkeby/Mainnet
-//    bytes32 constant internal API3_VOTING_APP_ID = 0x323c4eb511f386e7972d45b948cc546db35e9ccc7161c056fb07e09abd87e554;
+    // The Api3Voting app ID below is used on Rinkeby/Mainnet
+    // It is derived using `namehash("api3voting.open.aragonpm.eth")`
+    // bytes32 constant internal API3_VOTING_APP_ID = 0x323c4eb511f386e7972d45b948cc546db35e9ccc7161c056fb07e09abd87e554;
+
+    // The Api3Voting app ID below is used on localhost
+    // It is derived using `namehash("api3voting.aragonpm.eth")`
     bytes32 constant internal API3_VOTING_APP_ID = 0x727a0cf100ef0e645bad5a5b920d7fb71f8fd0eaf0fa579c341a045f597526f5;
+
     string constant private ERROR_BAD_VOTE_SETTINGS = "API3_DAO_BAD_VOTE_SETTINGS";
 
     address private constant ANY_ENTITY = address(-1);

--- a/packages/dao/package.json
+++ b/packages/dao/package.json
@@ -28,7 +28,8 @@
     "publish:staging": "aragon apm publish major $(npm run deploy:staging | tail -n 1) --environment staging",
     "publish:rinkeby": "aragon apm publish major $(npm run deploy:rinkeby | tail -n 1) --environment rinkeby",
     "publish:ropsten": "aragon apm publish major $(npm run deploy:ropsten | tail -n 1) --environment ropsten",
-    "publish:mainnet": "aragon apm publish major $(npm run deploy:mainnet | tail -n 1) --environment mainnet"
+    "publish:mainnet": "aragon apm publish major $(npm run deploy:mainnet | tail -n 1) --environment mainnet",
+    "derive-namehash": "node ./scripts/deriveNamehash.js"
   },
   "dependencies": {
     "@api3-dao/api3-voting": "^1.0.0",

--- a/packages/dao/scripts/deriveNamehash.js
+++ b/packages/dao/scripts/deriveNamehash.js
@@ -1,0 +1,2 @@
+const namehash = require('eth-ens-namehash')
+console.log(namehash.hash('api3voting.open.aragonpm.eth'));

--- a/packages/dao/scripts/deriveNamehash.js
+++ b/packages/dao/scripts/deriveNamehash.js
@@ -1,2 +1,6 @@
-const namehash = require('eth-ens-namehash')
-console.log(namehash.hash('api3voting.open.aragonpm.eth'));
+const namehash = require("eth-ens-namehash");
+console.log(
+  `namehash("api3voting.open.aragonpm.eth"): ${namehash.hash(
+    "api3voting.open.aragonpm.eth"
+  )}`
+);

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -64,7 +64,7 @@ describe("constructor", function () {
         expect(
           await api3Pool.claimsManagerStatus(roles.randomPerson.address)
         ).to.equal(false);
-  
+
         // Verify the default DAO parameters
         expect(await api3Pool.stakeTarget()).to.equal(
           ethers.BigNumber.from("50" + "000" + "000")
@@ -86,7 +86,7 @@ describe("constructor", function () {
         );
         // Initialize the APR at max APR
         expect(await api3Pool.currentApr()).to.equal(await api3Pool.maxApr());
-  
+
         // Token address set correctly
         expect(await api3Pool.api3Token()).to.equal(api3Token.address);
         // Initialize share price at 1
@@ -113,7 +113,10 @@ describe("constructor", function () {
           roles.deployer
         );
         await expect(
-          api3PoolFactory.deploy(api3Token.address, ethers.constants.AddressZero)
+          api3PoolFactory.deploy(
+            api3Token.address,
+            ethers.constants.AddressZero
+          )
         ).to.be.revertedWith("Invalid TimelockManager");
       });
     });
@@ -125,7 +128,10 @@ describe("constructor", function () {
         roles.deployer
       );
       await expect(
-        api3PoolFactory.deploy(ethers.constants.AddressZero, roles.mockTimelockManager.address)
+        api3PoolFactory.deploy(
+          ethers.constants.AddressZero,
+          roles.mockTimelockManager.address
+        )
       ).to.be.revertedWith("Invalid Api3Token");
     });
   });
@@ -214,17 +220,17 @@ describe("setDaoApps", function () {
     });
     context("Caller is not deployer", function () {
       it("reverts", async function () {
-      await expect(
-        api3Pool
-          .connect(roles.randomPerson)
-          .setDaoApps(
-            roles.agentAppPrimary.address,
-            roles.agentAppSecondary.address,
-            roles.votingAppPrimary.address,
-            roles.votingAppSecondary.address
-          )
-      ).to.be.revertedWith("Unauthorized");
-          });
+        await expect(
+          api3Pool
+            .connect(roles.randomPerson)
+            .setDaoApps(
+              roles.agentAppPrimary.address,
+              roles.agentAppSecondary.address,
+              roles.votingAppPrimary.address,
+              roles.votingAppSecondary.address
+            )
+        ).to.be.revertedWith("Unauthorized");
+      });
     });
   });
   context("DAO apps are set before", function () {


### PR DESCRIPTION
Added docs to allow the users to verify where the Api3Voting app ID in `Api3Template.sol` comes from. Added some more docs to describe the entire DAO+pool configuration. We will actively encourage the users to do this verification themselves.