### PR TITLE
[QSP-10] Add additional warnings about setting claims managers

### DIFF
--- a/packages/dao/README.md
+++ b/packages/dao/README.md
@@ -51,6 +51,7 @@ aragon dao acl <DAO kernel address> --use-frame
 7. Check that the following values are initialized correctly
 - `api3Pool` and the voting parameters (`supportRequiredPct` and `minAcceptQuorumPct`) at the Api3Voting apps
 - `api3Token`, `timelockManager`, `agentAppPrimary`, `agentAppSecondary`, `votingAppPrimary` and `votingAppSecondary` at the pool contract
+- If any claims manager contracts are set for the pool, they are audited and implemented to pay out claims in a trustless way with fail-safes such as payout limits (note that the pool will be deployed with no claims managers set initially)
 
 ## Permissions
 

--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -92,6 +92,9 @@ For example, such a contract can be implemented as an integration to a dispute r
 Note that it is intended that whether the claims will be paid out gets decided by a third party, and not the API3 DAO.
 It is expected for claims manager contracts to implement mechanisms to avoid catastrophic failure, for example by putting an upper limit to the total amount of payouts they can make within a limited period of time.
 
+The pool will not have any claims managers set at initialization, as the insurance product will not be active yet.
+If/when a proposal gets made to set a claims manager contract, you are recommended to review the contract yourself and/or refer to the audit reports to understand the implications.
+
 ### Claim evasion protection
 
 Users may unstake to frontrun an insurance claim/payout to avoid being slashed.

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -272,6 +272,11 @@ contract StateUtils is IStateUtils {
     /// withdraw as many tokens as it wants from the pool to pay out insurance
     /// claims.
     /// Only the primary Agent can do this because it is a critical operation.
+    /// WARNING: A compromised contract being given claims manager status may
+    /// result in loss of staked funds. If a proposal has been made to call
+    /// this method to set a contract as a claims manager, you are recommended
+    /// to review the contract yourself and/or refer to the audit reports to
+    /// understand the implications.
     /// @param claimsManager Claims manager contract address
     /// @param status Authorization status
     function setClaimsManagerStatus(


### PR DESCRIPTION
Claims manager contracts will be set/reset through a primary voting app proposal, which will have the primary agent call the pool contract. It is expected for the voter to refer to the pool source code to see what `setClaimsManagerStatus()` does, which is why we chose to emphasize the weight of this call in the NatSpec. Additional statements are added to the README and the importance of this type of proposals will be communicated to the user when they get made.
