### PR TITLE
[QSP-12] Remove unnecessary clipping

### DIFF
--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -114,9 +114,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         if (delta) {
             newDelegatedTo = currentlyDelegatedTo + shares;
         } else {
-            newDelegatedTo = currentlyDelegatedTo > shares 
-                ? currentlyDelegatedTo - shares
-                : 0;
+            newDelegatedTo = currentlyDelegatedTo - shares;
         }
         updateCheckpointArray(
             delegate.delegatedTo,


### PR DESCRIPTION
This clipping operation was a leftover from a previous version of the implementation where the value could go below 0 under some circumstances. This is no longer the case, and thus the clipping operation is removed as per the suggestion.
