### PR TITLE
[TO-1,2] Restrict delegations to prevent double votes/proposals

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -256,7 +256,16 @@ contract Api3Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
-        (, , , , , uint256 mostRecentProposalTimestamp) = api3Pool.getUser(msg.sender);
+        (
+            , // unstaked
+            , // vesting
+            , // unstakeScheduledFor
+            , // unstakeAmount
+            uint256 mostRecentProposalTimestamp,
+            , // mostRecentVoteTimestamp
+            , // mostRecentDelegationTimestamp
+            // mostRecentUndelegationTimestamp
+            ) = api3Pool.getUser(msg.sender);
         require(mostRecentProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         api3Pool.updateMostRecentProposalTimestamp(msg.sender);
 
@@ -295,6 +304,7 @@ contract Api3Voting is IForwarder, AragonApp {
         bool _executesIfDecided
     ) internal
     {
+        api3Pool.updateMostRecentVoteTimestamp(msg.sender);
         Vote storage vote_ = votes[_voteId];
 
         // This could re-enter, though we can assume the governance token is not malicious

--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -264,9 +264,10 @@ contract Api3Voting is IForwarder, AragonApp {
             uint256 mostRecentProposalTimestamp,
             , // mostRecentVoteTimestamp
             , // mostRecentDelegationTimestamp
-            // mostRecentUndelegationTimestamp
+            uint256 mostRecentUndelegationTimestamp
             ) = api3Pool.getUser(msg.sender);
         require(mostRecentProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
+        require(mostRecentUndelegationTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_UNDELEGATION_COOLDOWN");
         api3Pool.updateMostRecentProposalTimestamp(msg.sender);
 
         uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
@@ -304,6 +305,17 @@ contract Api3Voting is IForwarder, AragonApp {
         bool _executesIfDecided
     ) internal
     {
+        (
+            , // unstaked
+            , // vesting
+            , // unstakeScheduledFor
+            , // unstakeAmount
+            , // mostRecentProposalTimestamp
+            , // mostRecentVoteTimestamp
+            , // mostRecentDelegationTimestamp
+            uint256 mostRecentUndelegationTimestamp
+            ) = api3Pool.getUser(msg.sender);
+        require(mostRecentUndelegationTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_UNDELEGATION_COOLDOWN");
         api3Pool.updateMostRecentVoteTimestamp(msg.sender);
         Vote storage vote_ = votes[_voteId];
 

--- a/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
+++ b/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
@@ -31,15 +31,20 @@ interface IApi3Pool {
     function updateMostRecentProposalTimestamp(address userAddress)
         external;
 
+    function updateMostRecentVoteTimestamp(address userAddress)
+        external;
+
     function getUser(address userAddress)
         external
         view
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
             uint256 unstakeScheduledFor,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 mostRecentProposalTimestamp,
+            uint256 mostRecentVoteTimestamp,
+            uint256 mostRecentDelegationTimestamp,
+            uint256 mostRecentUndelegationTimestamp
             );
 }

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -83,21 +83,30 @@ contract Api3TokenMock is MiniMeToken {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
             uint256 unstakeScheduledFor,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 mostRecentProposalTimestamp,
+            uint256 mostRecentVoteTimestamp,
+            uint256 mostRecentDelegationTimestamp,
+            uint256 mostRecentUndelegationTimestamp
             )
     {
         unstaked = 0;
         vesting = 0;
-        lastDelegationUpdateTimestamp = 0;
         unstakeScheduledFor = 0;
         unstakeAmount = 0;
         mostRecentProposalTimestamp = 0;
+        mostRecentVoteTimestamp = 0;
+        mostRecentDelegationTimestamp = 0;
+        mostRecentUndelegationTimestamp = 0;
     }
 
     function updateMostRecentProposalTimestamp(address userAddress)
+        external
+    {
+    }
+
+    function updateMostRecentVoteTimestamp(address userAddress)
         external
     {
     }

--- a/packages/api3-voting/test/delegation-integration.js
+++ b/packages/api3-voting/test/delegation-integration.js
@@ -133,7 +133,7 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
             // await pool.delegateVotingPower(voter2, {from: voter1});
             await expectRevert(
                 pool.delegateVotingPower(voter2, {from: voter1}),
-                "Cannot delegate to the same address"
+                "Unauthorized"
             );
             latest = Number(await time.latest());
             await time.increaseTo(latest+Number(time.duration.weeks(1)));

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -26,10 +26,11 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         // Do not allow frequent delegation updates as that can be used to spam
         // proposals
         require(
-            user.lastDelegationUpdateTimestamp <= block.timestamp - EPOCH_LENGTH,
+            user.mostRecentDelegationTimestamp <= block.timestamp - EPOCH_LENGTH
+                && user.mostRecentUndelegationTimestamp <= block.timestamp - EPOCH_LENGTH,
             ERROR_UNAUTHORIZED
             );
-        user.lastDelegationUpdateTimestamp = block.timestamp;
+        user.mostRecentDelegationTimestamp = block.timestamp;
         uint256 userShares = userShares(msg.sender);
         address userDelegate = userDelegate(msg.sender);
 
@@ -69,7 +70,8 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         address userDelegate = userDelegate(msg.sender);
         require(
             userDelegate != address(0)
-                && user.lastDelegationUpdateTimestamp <= block.timestamp - EPOCH_LENGTH,
+                && user.mostRecentDelegationTimestamp <= block.timestamp - EPOCH_LENGTH
+                && user.mostRecentUndelegationTimestamp <= block.timestamp - EPOCH_LENGTH,
             ERROR_UNAUTHORIZED
             );
 
@@ -83,7 +85,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             fromBlock: block.number,
             _address: address(0)
             }));
-        user.lastDelegationUpdateTimestamp = block.timestamp;
+        user.mostRecentUndelegationTimestamp = block.timestamp;
         emit Undelegated(
             msg.sender,
             userDelegate

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -77,8 +77,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         address userDelegate = userDelegate(msg.sender);
         require(
             userDelegate != address(0)
-                && user.mostRecentDelegationTimestamp + EPOCH_LENGTH < block.timestamp 
-                && user.mostRecentUndelegationTimestamp + EPOCH_LENGTH < block.timestamp,
+                && user.mostRecentDelegationTimestamp + EPOCH_LENGTH < block.timestamp,
             ERROR_UNAUTHORIZED
             );
 

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -26,15 +26,15 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         // Do not allow frequent delegation updates as that can be used to spam
         // proposals
         require(
-            user.mostRecentDelegationTimestamp <= block.timestamp - EPOCH_LENGTH
-                && user.mostRecentUndelegationTimestamp <= block.timestamp - EPOCH_LENGTH,
+            user.mostRecentDelegationTimestamp + EPOCH_LENGTH < block.timestamp
+                && user.mostRecentUndelegationTimestamp + EPOCH_LENGTH <= block.timestamp,
             ERROR_UNAUTHORIZED
             );
         // Do not allow the user to delegate if they have voted or made a proposal
         // recently
         require(
-            user.mostRecentProposalTimestamp <= block.timestamp - EPOCH_LENGTH
-                && user.mostRecentVoteTimestamp <= block.timestamp - EPOCH_LENGTH,
+            user.mostRecentProposalTimestamp + EPOCH_LENGTH < block.timestamp
+                && user.mostRecentVoteTimestamp + EPOCH_LENGTH < block.timestamp,
             ERROR_UNAUTHORIZED
             );
         user.mostRecentDelegationTimestamp = block.timestamp;
@@ -77,8 +77,8 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         address userDelegate = userDelegate(msg.sender);
         require(
             userDelegate != address(0)
-                && user.mostRecentDelegationTimestamp <= block.timestamp - EPOCH_LENGTH
-                && user.mostRecentUndelegationTimestamp <= block.timestamp - EPOCH_LENGTH,
+                && user.mostRecentDelegationTimestamp + EPOCH_LENGTH < block.timestamp 
+                && user.mostRecentUndelegationTimestamp + EPOCH_LENGTH < block.timestamp,
             ERROR_UNAUTHORIZED
             );
 

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -30,6 +30,13 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
                 && user.mostRecentUndelegationTimestamp <= block.timestamp - EPOCH_LENGTH,
             ERROR_UNAUTHORIZED
             );
+        // Do not allow the user to delegate if they have voted or made a proposal
+        // recently
+        require(
+            user.mostRecentProposalTimestamp <= block.timestamp - EPOCH_LENGTH
+                && user.mostRecentVoteTimestamp <= block.timestamp - EPOCH_LENGTH,
+            ERROR_UNAUTHORIZED
+            );
         user.mostRecentDelegationTimestamp = block.timestamp;
         uint256 userShares = userShares(msg.sender);
         address userDelegate = userDelegate(msg.sender);

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -231,12 +231,16 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     /// @param userAddress User address
     /// @return unstaked Amount of unstaked API3 tokens
     /// @return vesting Amount of API3 tokens locked by vesting
-    /// @return lastDelegationUpdateTimestamp Time of most recent delegation
-    /// update
     /// @return unstakeScheduledFor Time unstaking is scheduled for
     /// @return unstakeAmount Amount scheduled to unstake
     /// @return mostRecentProposalTimestamp Time when the user made their most
     /// recent proposal
+    /// @return mostRecentVoteTimestamp Time when the user cast their most
+    /// recent vote
+    /// @return mostRecentDelegationTimestamp Time when the user made their
+    /// most recent delegation
+    /// @return mostRecentUndelegationTimestamp Time when the user made their
+    /// most recent undelegation
     function getUser(address userAddress)
         external
         view
@@ -244,19 +248,23 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
             uint256 unstakeScheduledFor,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 mostRecentProposalTimestamp,
+            uint256 mostRecentVoteTimestamp,
+            uint256 mostRecentDelegationTimestamp,
+            uint256 mostRecentUndelegationTimestamp
             )
     {
         User storage user = users[userAddress];
         unstaked = user.unstaked;
         vesting = user.vesting;
-        lastDelegationUpdateTimestamp = user.lastDelegationUpdateTimestamp;
         unstakeScheduledFor = user.unstakeScheduledFor;
         unstakeAmount = user.unstakeAmount;
         mostRecentProposalTimestamp = user.mostRecentProposalTimestamp;
+        mostRecentVoteTimestamp = user.mostRecentVoteTimestamp;
+        mostRecentDelegationTimestamp = user.mostRecentDelegationTimestamp;
+        mostRecentUndelegationTimestamp = user.mostRecentUndelegationTimestamp;
     }
 
     /// @notice Called to get the value of a checkpoint array at a specific

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -61,7 +61,6 @@ contract StateUtils is IStateUtils {
     string internal constant ERROR_VALUE = "Invalid value";
     string internal constant ERROR_ADDRESS = "Invalid address";
     string internal constant ERROR_UNAUTHORIZED = "Unauthorized";
-    string internal constant ERROR_DELEGATE = "Cannot delegate to the same address";
 
     // All percentage values are represented by multiplying by 1e6
     uint256 internal constant ONE_PERCENT = 1_000_000;

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -481,6 +481,11 @@ contract StateUtils is IStateUtils {
         onlyVotingApp()
     {
         users[userAddress].mostRecentVoteTimestamp = block.timestamp;
+        emit UpdatedMostRecentVoteTimestamp(
+            msg.sender,
+            userAddress,
+            block.timestamp
+            );
     }
 
     /// @notice Called internally to update the total shares history

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -23,15 +23,17 @@ contract StateUtils is IStateUtils {
     }
 
     struct User {
-        uint256 unstaked;
-        uint256 vesting;
         Checkpoint[] shares;
         AddressCheckpoint[] delegates;
         Checkpoint[] delegatedTo;
-        uint256 lastDelegationUpdateTimestamp;
+        uint256 unstaked;
+        uint256 vesting;
         uint256 unstakeScheduledFor;
         uint256 unstakeAmount;
         uint256 mostRecentProposalTimestamp;
+        uint256 mostRecentVoteTimestamp;
+        uint256 mostRecentDelegationTimestamp;
+        uint256 mostRecentUndelegationTimestamp;
     }
 
     struct LockedCalculationState {
@@ -468,6 +470,17 @@ contract StateUtils is IStateUtils {
             userAddress,
             block.timestamp
             );
+    }
+
+        /// @notice Called by a DAO Api3Voting app at voting-time to update the
+    /// timestamp of the user's most recent vote
+    /// @param userAddress User address
+    function updateMostRecentVoteTimestamp(address userAddress)
+        external
+        override
+        onlyVotingApp()
+    {
+        users[userAddress].mostRecentVoteTimestamp = block.timestamp;
     }
 
     /// @notice Called internally to update the total shares history

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -82,9 +82,11 @@ interface IGetterUtils is IStateUtils {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
             uint256 unstakeScheduledFor,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 mostRecentProposalTimestamp,
+            uint256 mostRecentVoteTimestamp,
+            uint256 mostRecentDelegationTimestamp,
+            uint256 mostRecentUndelegationTimestamp
             );
 }

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -63,6 +63,12 @@ interface IStateUtils {
         uint256 mostRecentProposalTimestamp
         );
 
+    event UpdatedMostRecentVoteTimestamp(
+        address votingApp,
+        address userAddress,
+        uint256 mostRecentVoteTimestamp
+        );
+
     function setDaoApps(
         address _agentAppPrimary,
         address _agentAppSecondary,

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -107,4 +107,7 @@ interface IStateUtils {
 
     function updateMostRecentProposalTimestamp(address userAddress)
         external;
+
+    function updateMostRecentVoteTimestamp(address userAddress)
+        external;
 }

--- a/packages/pool/contracts/mock/MockApi3Voting.sol
+++ b/packages/pool/contracts/mock/MockApi3Voting.sol
@@ -17,4 +17,10 @@ contract MockApi3Voting {
         api3Pool.updateLastVoteSnapshotBlock(block.number - 1);
         api3Pool.updateMostRecentProposalTimestamp(userAddress);
     }
+
+    function vote(address userAddress)
+        external
+    {
+        api3Pool.updateMostRecentVoteTimestamp(userAddress);
+    }
 }

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -92,7 +92,7 @@ describe("delegateVotingPower", function () {
                 ).to.equal(user1Stake);
                 // Fast forward time
                 await ethers.provider.send("evm_increaseTime", [
-                  EPOCH_LENGTH.toNumber(),
+                  EPOCH_LENGTH.toNumber() + 1,
                 ]);
                 // ... then have user 1 delegate to user 2
                 await expect(
@@ -145,7 +145,7 @@ describe("delegateVotingPower", function () {
                   .delegateVotingPower(roles.user2.address);
                 // Fast forward time
                 await ethers.provider.send("evm_increaseTime", [
-                  EPOCH_LENGTH.toNumber(),
+                  EPOCH_LENGTH.toNumber() + 1,
                 ]);
                 // ... then have user 1 delegate to user 2 again
                 await expect(
@@ -245,7 +245,7 @@ describe("undelegateVotingPower", function () {
             .delegateVotingPower(roles.user2.address);
           // Fast forward time
           await ethers.provider.send("evm_increaseTime", [
-            EPOCH_LENGTH.toNumber(),
+            EPOCH_LENGTH.toNumber() + 1,
           ]);
           // Have user 1 undelegate
           await expect(api3Pool.connect(roles.user1).undelegateVotingPower())

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -54,7 +54,7 @@ describe("delegateVotingPower", function () {
   context("Delegate address is not zero", function () {
     context("Delegate address is not caller", function () {
       context("Delegate is not delegating", function () {
-        context("User has not delegated less than an epoch ago", function () {
+        context("User is not delegating", function () {
           context(
             "User has not undelegated less than an epoch ago",
             function () {
@@ -64,130 +64,54 @@ describe("delegateVotingPower", function () {
                   context(
                     "User has not voted less than an epoch ago",
                     function () {
-                      context(
-                        "User did not have the same delegate",
-                        function () {
-                          it("delegates voting power", async function () {
-                            // Have two users stake
-                            const user1Stake = ethers.utils.parseEther(
-                              "20" + "000" + "000"
-                            );
-                            const user2Stake = ethers.utils.parseEther(
-                              "60" + "000" + "000"
-                            );
-                            await api3Token
-                              .connect(roles.deployer)
-                              .transfer(roles.user1.address, user1Stake);
-                            await api3Token
-                              .connect(roles.deployer)
-                              .transfer(roles.user2.address, user2Stake);
-                            await api3Token
-                              .connect(roles.user1)
-                              .approve(api3Pool.address, user1Stake);
-                            await api3Token
-                              .connect(roles.user2)
-                              .approve(api3Pool.address, user2Stake);
-                            await api3Pool
-                              .connect(roles.user1)
-                              .depositAndStake(user1Stake);
-                            await api3Pool
-                              .connect(roles.user2)
-                              .depositAndStake(user2Stake);
-                            // Have user 1 delegate to someone else first
-                            await api3Pool
-                              .connect(roles.user1)
-                              .delegateVotingPower(roles.randomPerson.address);
-                            expect(
-                              await api3Pool.balanceOf(roles.user1.address)
-                            ).to.equal(ethers.BigNumber.from(0));
-                            expect(
-                              await api3Pool.balanceOf(
-                                roles.randomPerson.address
-                              )
-                            ).to.equal(user1Stake);
-                            // Fast forward time
-                            await ethers.provider.send("evm_increaseTime", [
-                              EPOCH_LENGTH.toNumber() + 1,
-                            ]);
-                            // ... then have user 1 delegate to user 2
-                            await expect(
-                              api3Pool
-                                .connect(roles.user1)
-                                .delegateVotingPower(roles.user2.address)
-                            )
-                              .to.emit(api3Pool, "Delegated")
-                              .withArgs(
-                                roles.user1.address,
-                                roles.user2.address
-                              );
-                            expect(
-                              await api3Pool.balanceOf(roles.user1.address)
-                            ).to.equal(ethers.BigNumber.from(0));
-                            expect(
-                              await api3Pool.balanceOf(roles.user2.address)
-                            ).to.equal(user2Stake.add(user1Stake));
-                            expect(
-                              await api3Pool.userReceivedDelegation(
-                                roles.user2.address
-                              )
-                            ).to.equal(user1Stake);
-                            expect(
-                              await api3Pool.userDelegate(roles.user1.address)
-                            ).to.equal(roles.user2.address);
-                          });
-                        }
-                      );
-                      context("User had the same delegate", function () {
-                        it("reverts", async function () {
-                          // Have two users stake
-                          const user1Stake = ethers.utils.parseEther(
-                            "20" + "000" + "000"
-                          );
-                          const user2Stake = ethers.utils.parseEther(
-                            "60" + "000" + "000"
-                          );
-                          await api3Token
-                            .connect(roles.deployer)
-                            .transfer(roles.user1.address, user1Stake);
-                          await api3Token
-                            .connect(roles.deployer)
-                            .transfer(roles.user2.address, user2Stake);
-                          await api3Token
+                      it("delegates voting power", async function () {
+                        // Have two users stake
+                        const user1Stake = ethers.utils.parseEther(
+                          "20" + "000" + "000"
+                        );
+                        const user2Stake = ethers.utils.parseEther(
+                          "60" + "000" + "000"
+                        );
+                        await api3Token
+                          .connect(roles.deployer)
+                          .transfer(roles.user1.address, user1Stake);
+                        await api3Token
+                          .connect(roles.deployer)
+                          .transfer(roles.user2.address, user2Stake);
+                        await api3Token
+                          .connect(roles.user1)
+                          .approve(api3Pool.address, user1Stake);
+                        await api3Token
+                          .connect(roles.user2)
+                          .approve(api3Pool.address, user2Stake);
+                        await api3Pool
+                          .connect(roles.user1)
+                          .depositAndStake(user1Stake);
+                        await api3Pool
+                          .connect(roles.user2)
+                          .depositAndStake(user2Stake);
+                        // Have user 1 delegate to user 2
+                        await expect(
+                          api3Pool
                             .connect(roles.user1)
-                            .approve(api3Pool.address, user1Stake);
-                          await api3Token
-                            .connect(roles.user2)
-                            .approve(api3Pool.address, user2Stake);
-                          await api3Pool
-                            .connect(roles.user1)
-                            .depositAndStake(user1Stake);
-                          await api3Pool
-                            .connect(roles.user2)
-                            .depositAndStake(user2Stake);
-                          // Have user 1 delegate to user 2
-                          await api3Pool
-                            .connect(roles.user1)
-                            .delegateVotingPower(roles.user2.address);
-                          // Fast forward time
-                          await ethers.provider.send("evm_increaseTime", [
-                            EPOCH_LENGTH.toNumber() + 1,
-                          ]);
-                          // ... then have user 1 delegate to user 2 again
-                          await expect(
-                            api3Pool
-                              .connect(roles.user1)
-                              .delegateVotingPower(roles.user2.address)
-                          ).to.be.revertedWith(
-                            "Cannot delegate to the same address"
-                          );
-
-                          expect(
-                            await api3Pool.balanceOf(roles.user1.address)
-                          ).to.equal(ethers.BigNumber.from(0));
-                          expect(
-                            await api3Pool.balanceOf(roles.user2.address)
-                          ).to.equal(user2Stake.add(user1Stake));
-                        });
+                            .delegateVotingPower(roles.user2.address)
+                        )
+                          .to.emit(api3Pool, "Delegated")
+                          .withArgs(roles.user1.address, roles.user2.address);
+                        expect(
+                          await api3Pool.balanceOf(roles.user1.address)
+                        ).to.equal(ethers.BigNumber.from(0));
+                        expect(
+                          await api3Pool.balanceOf(roles.user2.address)
+                        ).to.equal(user2Stake.add(user1Stake));
+                        expect(
+                          await api3Pool.userReceivedDelegation(
+                            roles.user2.address
+                          )
+                        ).to.equal(user1Stake);
+                        expect(
+                          await api3Pool.userDelegate(roles.user1.address)
+                        ).to.equal(roles.user2.address);
                       });
                     }
                   );
@@ -226,6 +150,12 @@ describe("delegateVotingPower", function () {
               await api3Pool
                 .connect(roles.user1)
                 .delegateVotingPower(roles.randomPerson.address);
+              // Fast forward time
+              await ethers.provider.send("evm_increaseTime", [
+                EPOCH_LENGTH.toNumber() + 1,
+              ]);
+              // Have user 1 undelegate
+              await api3Pool.connect(roles.user1).undelegateVotingPower();
               // Attempt to have user 1 delegate to user 2 without waiting
               await expect(
                 api3Pool
@@ -235,19 +165,13 @@ describe("delegateVotingPower", function () {
             });
           });
         });
-        context("User has delegated less than an epoch ago", function () {
+        context("User is delegating", function () {
           it("reverts", async function () {
             // Have user 1 delegate to someone else first
             await api3Pool
               .connect(roles.user1)
               .delegateVotingPower(roles.randomPerson.address);
-            // Fast forward time
-            await ethers.provider.send("evm_increaseTime", [
-              EPOCH_LENGTH.toNumber() + 1,
-            ]);
-            // Have user 1 undelegate
-            await api3Pool.connect(roles.user1).undelegateVotingPower();
-            // Attempt to have user 1 delegate to user 2 without waiting
+            // Attempt to have user 1 delegate to user 2
             await expect(
               api3Pool
                 .connect(roles.user1)

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -54,119 +54,173 @@ describe("delegateVotingPower", function () {
   context("Delegate address is not zero", function () {
     context("Delegate address is not caller", function () {
       context("Delegate is not delegating", function () {
-        context(
-          "User has not updated their delegation status less than reward epoch ago",
-          function () {
-            context("User did not have the same delegate", function () {
-              it("delegates voting power", async function () {
-                // Have two users stake
-                const user1Stake = ethers.utils.parseEther(
-                  "20" + "000" + "000"
-                );
-                const user2Stake = ethers.utils.parseEther(
-                  "60" + "000" + "000"
-                );
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user1.address, user1Stake);
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user2.address, user2Stake);
-                await api3Token
-                  .connect(roles.user1)
-                  .approve(api3Pool.address, user1Stake);
-                await api3Token
-                  .connect(roles.user2)
-                  .approve(api3Pool.address, user2Stake);
-                await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
-                await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
-                // Have user 1 delegate to someone else first
-                await api3Pool
-                  .connect(roles.user1)
-                  .delegateVotingPower(roles.randomPerson.address);
-                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
-                  ethers.BigNumber.from(0)
-                );
-                expect(
-                  await api3Pool.balanceOf(roles.randomPerson.address)
-                ).to.equal(user1Stake);
-                // Fast forward time
-                await ethers.provider.send("evm_increaseTime", [
-                  EPOCH_LENGTH.toNumber() + 1,
-                ]);
-                // ... then have user 1 delegate to user 2
-                await expect(
-                  api3Pool
-                    .connect(roles.user1)
-                    .delegateVotingPower(roles.user2.address)
-                )
-                  .to.emit(api3Pool, "Delegated")
-                  .withArgs(roles.user1.address, roles.user2.address);
-                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
-                  ethers.BigNumber.from(0)
-                );
-                expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
-                  user2Stake.add(user1Stake)
-                );
-                expect(
-                  await api3Pool.userReceivedDelegation(roles.user2.address)
-                ).to.equal(user1Stake);
-                expect(
-                  await api3Pool.userDelegate(roles.user1.address)
-                ).to.equal(roles.user2.address);
-              });
-            });
-            context("User had the same delegate", function () {
-              it("reverts", async function () {
-                // Have two users stake
-                const user1Stake = ethers.utils.parseEther(
-                  "20" + "000" + "000"
-                );
-                const user2Stake = ethers.utils.parseEther(
-                  "60" + "000" + "000"
-                );
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user1.address, user1Stake);
-                await api3Token
-                  .connect(roles.deployer)
-                  .transfer(roles.user2.address, user2Stake);
-                await api3Token
-                  .connect(roles.user1)
-                  .approve(api3Pool.address, user1Stake);
-                await api3Token
-                  .connect(roles.user2)
-                  .approve(api3Pool.address, user2Stake);
-                await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
-                await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
-                // Have user 1 delegate to user 2
-                await api3Pool
-                  .connect(roles.user1)
-                  .delegateVotingPower(roles.user2.address);
-                // Fast forward time
-                await ethers.provider.send("evm_increaseTime", [
-                  EPOCH_LENGTH.toNumber() + 1,
-                ]);
-                // ... then have user 1 delegate to user 2 again
-                await expect(
-                  api3Pool
-                    .connect(roles.user1)
-                    .delegateVotingPower(roles.user2.address)
-                ).to.be.revertedWith("Cannot delegate to the same address");
+        context("User has not delegated less than an epoch ago", function () {
+          context(
+            "User has not undelegated less than an epoch ago",
+            function () {
+              context(
+                "User has not created a proposal less than an epoch ago",
+                function () {
+                  context(
+                    "User has not voted less than an epoch ago",
+                    function () {
+                      context(
+                        "User did not have the same delegate",
+                        function () {
+                          it("delegates voting power", async function () {
+                            // Have two users stake
+                            const user1Stake = ethers.utils.parseEther(
+                              "20" + "000" + "000"
+                            );
+                            const user2Stake = ethers.utils.parseEther(
+                              "60" + "000" + "000"
+                            );
+                            await api3Token
+                              .connect(roles.deployer)
+                              .transfer(roles.user1.address, user1Stake);
+                            await api3Token
+                              .connect(roles.deployer)
+                              .transfer(roles.user2.address, user2Stake);
+                            await api3Token
+                              .connect(roles.user1)
+                              .approve(api3Pool.address, user1Stake);
+                            await api3Token
+                              .connect(roles.user2)
+                              .approve(api3Pool.address, user2Stake);
+                            await api3Pool
+                              .connect(roles.user1)
+                              .depositAndStake(user1Stake);
+                            await api3Pool
+                              .connect(roles.user2)
+                              .depositAndStake(user2Stake);
+                            // Have user 1 delegate to someone else first
+                            await api3Pool
+                              .connect(roles.user1)
+                              .delegateVotingPower(roles.randomPerson.address);
+                            expect(
+                              await api3Pool.balanceOf(roles.user1.address)
+                            ).to.equal(ethers.BigNumber.from(0));
+                            expect(
+                              await api3Pool.balanceOf(
+                                roles.randomPerson.address
+                              )
+                            ).to.equal(user1Stake);
+                            // Fast forward time
+                            await ethers.provider.send("evm_increaseTime", [
+                              EPOCH_LENGTH.toNumber() + 1,
+                            ]);
+                            // ... then have user 1 delegate to user 2
+                            await expect(
+                              api3Pool
+                                .connect(roles.user1)
+                                .delegateVotingPower(roles.user2.address)
+                            )
+                              .to.emit(api3Pool, "Delegated")
+                              .withArgs(
+                                roles.user1.address,
+                                roles.user2.address
+                              );
+                            expect(
+                              await api3Pool.balanceOf(roles.user1.address)
+                            ).to.equal(ethers.BigNumber.from(0));
+                            expect(
+                              await api3Pool.balanceOf(roles.user2.address)
+                            ).to.equal(user2Stake.add(user1Stake));
+                            expect(
+                              await api3Pool.userReceivedDelegation(
+                                roles.user2.address
+                              )
+                            ).to.equal(user1Stake);
+                            expect(
+                              await api3Pool.userDelegate(roles.user1.address)
+                            ).to.equal(roles.user2.address);
+                          });
+                        }
+                      );
+                      context("User had the same delegate", function () {
+                        it("reverts", async function () {
+                          // Have two users stake
+                          const user1Stake = ethers.utils.parseEther(
+                            "20" + "000" + "000"
+                          );
+                          const user2Stake = ethers.utils.parseEther(
+                            "60" + "000" + "000"
+                          );
+                          await api3Token
+                            .connect(roles.deployer)
+                            .transfer(roles.user1.address, user1Stake);
+                          await api3Token
+                            .connect(roles.deployer)
+                            .transfer(roles.user2.address, user2Stake);
+                          await api3Token
+                            .connect(roles.user1)
+                            .approve(api3Pool.address, user1Stake);
+                          await api3Token
+                            .connect(roles.user2)
+                            .approve(api3Pool.address, user2Stake);
+                          await api3Pool
+                            .connect(roles.user1)
+                            .depositAndStake(user1Stake);
+                          await api3Pool
+                            .connect(roles.user2)
+                            .depositAndStake(user2Stake);
+                          // Have user 1 delegate to user 2
+                          await api3Pool
+                            .connect(roles.user1)
+                            .delegateVotingPower(roles.user2.address);
+                          // Fast forward time
+                          await ethers.provider.send("evm_increaseTime", [
+                            EPOCH_LENGTH.toNumber() + 1,
+                          ]);
+                          // ... then have user 1 delegate to user 2 again
+                          await expect(
+                            api3Pool
+                              .connect(roles.user1)
+                              .delegateVotingPower(roles.user2.address)
+                          ).to.be.revertedWith(
+                            "Cannot delegate to the same address"
+                          );
 
-                expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
-                  ethers.BigNumber.from(0)
-                );
-                expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
-                  user2Stake.add(user1Stake)
-                );
-              });
-            });
-          }
-        );
-        context(
-          "User has updated their delegation status less than reward epoch ago",
-          function () {
+                          expect(
+                            await api3Pool.balanceOf(roles.user1.address)
+                          ).to.equal(ethers.BigNumber.from(0));
+                          expect(
+                            await api3Pool.balanceOf(roles.user2.address)
+                          ).to.equal(user2Stake.add(user1Stake));
+                        });
+                      });
+                    }
+                  );
+                  context("User has voted less than an epoch ago", function () {
+                    it("reverts", async function () {
+                      await api3Voting.vote(roles.user1.address);
+                      // Attempt to have user 1 delegate to user 2 without waiting
+                      await expect(
+                        api3Pool
+                          .connect(roles.user1)
+                          .delegateVotingPower(roles.user2.address)
+                      ).to.be.revertedWith("Unauthorized");
+                    });
+                  });
+                }
+              );
+              context(
+                "User has created a proposal less than an epoch ago",
+                function () {
+                  it("reverts", async function () {
+                    await api3Voting.newVote(roles.user1.address);
+                    // Attempt to have user 1 delegate to user 2 without waiting
+                    await expect(
+                      api3Pool
+                        .connect(roles.user1)
+                        .delegateVotingPower(roles.user2.address)
+                    ).to.be.revertedWith("Unauthorized");
+                  });
+                }
+              );
+            }
+          );
+          context("User has undelegated less than an epoch ago", function () {
             it("reverts", async function () {
               // Have user 1 delegate to someone else first
               await api3Pool
@@ -179,8 +233,28 @@ describe("delegateVotingPower", function () {
                   .delegateVotingPower(roles.user2.address)
               ).to.be.revertedWith("Unauthorized");
             });
-          }
-        );
+          });
+        });
+        context("User has delegated less than an epoch ago", function () {
+          it("reverts", async function () {
+            // Have user 1 delegate to someone else first
+            await api3Pool
+              .connect(roles.user1)
+              .delegateVotingPower(roles.randomPerson.address);
+            // Fast forward time
+            await ethers.provider.send("evm_increaseTime", [
+              EPOCH_LENGTH.toNumber() + 1,
+            ]);
+            // Have user 1 undelegate
+            await api3Pool.connect(roles.user1).undelegateVotingPower();
+            // Attempt to have user 1 delegate to user 2 without waiting
+            await expect(
+              api3Pool
+                .connect(roles.user1)
+                .delegateVotingPower(roles.user2.address)
+            ).to.be.revertedWith("Unauthorized");
+          });
+        });
       });
       context("Delegate is delegating", function () {
         it("reverts", async function () {
@@ -218,69 +292,63 @@ describe("delegateVotingPower", function () {
 
 describe("undelegateVotingPower", function () {
   context("User has delegated before", function () {
-    context(
-      "User has not updated their delegation status less than reward epoch ago",
-      function () {
-        it("undelegates voting power", async function () {
-          // Have two users stake
-          const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-          const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user1.address, user1Stake);
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user2.address, user2Stake);
-          await api3Token
-            .connect(roles.user1)
-            .approve(api3Pool.address, user1Stake);
-          await api3Token
-            .connect(roles.user2)
-            .approve(api3Pool.address, user2Stake);
-          await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
-          await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
-          // Have user 1 delegate to user 2 first
-          await api3Pool
-            .connect(roles.user1)
-            .delegateVotingPower(roles.user2.address);
-          // Fast forward time
-          await ethers.provider.send("evm_increaseTime", [
-            EPOCH_LENGTH.toNumber() + 1,
-          ]);
-          // Have user 1 undelegate
-          await expect(api3Pool.connect(roles.user1).undelegateVotingPower())
-            .to.emit(api3Pool, "Undelegated")
-            .withArgs(roles.user1.address, roles.user2.address);
-          expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
-            user1Stake
-          );
-          expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
-            user2Stake
-          );
-          expect(
-            await api3Pool.userReceivedDelegation(roles.user2.address)
-          ).to.equal(ethers.BigNumber.from(0));
-          expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
-            ethers.constants.AddressZero
-          );
-        });
-      }
-    );
-    context(
-      "User has updated their delegation status less than reward epoch ago",
-      function () {
-        it("reverts", async function () {
-          // Have user 1 delegate to user 2 first
-          await api3Pool
-            .connect(roles.user1)
-            .delegateVotingPower(roles.user2.address);
-          // Attempt to have user 1 undelegate without waiting
-          await expect(
-            api3Pool.connect(roles.user1).undelegateVotingPower()
-          ).to.be.revertedWith("Unauthorized");
-        });
-      }
-    );
+    context("User has not delegated less than an epoch ago", function () {
+      it("undelegates voting power", async function () {
+        // Have two users stake
+        const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
+        const user2Stake = ethers.utils.parseEther("60" + "000" + "000");
+        await api3Token
+          .connect(roles.deployer)
+          .transfer(roles.user1.address, user1Stake);
+        await api3Token
+          .connect(roles.deployer)
+          .transfer(roles.user2.address, user2Stake);
+        await api3Token
+          .connect(roles.user1)
+          .approve(api3Pool.address, user1Stake);
+        await api3Token
+          .connect(roles.user2)
+          .approve(api3Pool.address, user2Stake);
+        await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
+        await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
+        // Have user 1 delegate to user 2 first
+        await api3Pool
+          .connect(roles.user1)
+          .delegateVotingPower(roles.user2.address);
+        // Fast forward time
+        await ethers.provider.send("evm_increaseTime", [
+          EPOCH_LENGTH.toNumber() + 1,
+        ]);
+        // Have user 1 undelegate
+        await expect(api3Pool.connect(roles.user1).undelegateVotingPower())
+          .to.emit(api3Pool, "Undelegated")
+          .withArgs(roles.user1.address, roles.user2.address);
+        expect(await api3Pool.balanceOf(roles.user1.address)).to.equal(
+          user1Stake
+        );
+        expect(await api3Pool.balanceOf(roles.user2.address)).to.equal(
+          user2Stake
+        );
+        expect(
+          await api3Pool.userReceivedDelegation(roles.user2.address)
+        ).to.equal(ethers.BigNumber.from(0));
+        expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
+          ethers.constants.AddressZero
+        );
+      });
+    });
+    context("User has delegated less than an epoch ago", function () {
+      it("reverts", async function () {
+        // Have user 1 delegate to user 2 first
+        await api3Pool
+          .connect(roles.user1)
+          .delegateVotingPower(roles.user2.address);
+        // Attempt to have user 1 undelegate without waiting
+        await expect(
+          api3Pool.connect(roles.user1).undelegateVotingPower()
+        ).to.be.revertedWith("Unauthorized");
+      });
+    });
   });
   context("User has not delegated before", function () {
     it("reverts", async function () {

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -447,12 +447,12 @@ describe("getUser", function () {
       proposalBlock.timestamp + 100,
     ]);
     await api3Voting.newVote(roles.user1.address);
-    // Have user1 delegate
+    // Have user1 delegate (need to wait an epoch to delegate after voting)
     const delegationBlock = await ethers.provider.getBlock(
       await ethers.provider.getBlockNumber()
     );
     await ethers.provider.send("evm_setNextBlockTimestamp", [
-      delegationBlock.timestamp + 100,
+      delegationBlock.timestamp + 100 + EPOCH_LENGTH.toNumber(),
     ]);
     await api3Pool
       .connect(roles.user1)
@@ -462,7 +462,7 @@ describe("getUser", function () {
     expect(user.unstaked).to.equal(userUnstaked);
     expect(user.vesting).to.equal(userVesting);
     expect(user.mostRecentDelegationTimestamp).to.equal(
-      delegationBlock.timestamp + 100
+      delegationBlock.timestamp + 100 + EPOCH_LENGTH.toNumber()
     );
     expect(user.unstakeScheduledFor).to.equal(unstakeScheduledFor);
     expect(user.unstakeAmount).to.equal(userScheduledToUnstake);

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -461,7 +461,7 @@ describe("getUser", function () {
     const user = await api3Pool.getUser(roles.user1.address);
     expect(user.unstaked).to.equal(userUnstaked);
     expect(user.vesting).to.equal(userVesting);
-    expect(user.lastDelegationUpdateTimestamp).to.equal(
+    expect(user.mostRecentDelegationTimestamp).to.equal(
       delegationBlock.timestamp + 100
     );
     expect(user.unstakeScheduledFor).to.equal(unstakeScheduledFor);

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -197,7 +197,21 @@ describe("getDelegateAt", function () {
         ]);
         await api3Pool
           .connect(roles.user1)
+          .undelegateVotingPower();
+        // Fast forward time
+        await ethers.provider.send("evm_increaseTime", [
+          EPOCH_LENGTH.toNumber() + 1,
+        ]);
+        await api3Pool
+          .connect(roles.user1)
           .delegateVotingPower(roles.randomPerson.address);
+        // Fast forward time
+        await ethers.provider.send("evm_increaseTime", [
+          EPOCH_LENGTH.toNumber() + 1,
+        ]);
+        await api3Pool
+          .connect(roles.user1)
+          .undelegateVotingPower();
         // Fast forward time
         await ethers.provider.send("evm_increaseTime", [
           EPOCH_LENGTH.toNumber() + 1,
@@ -217,11 +231,23 @@ describe("getDelegateAt", function () {
             roles.user1.address,
             firstBlockNumber + 1
           )
-        ).to.equal(roles.randomPerson.address);
+        ).to.equal(ethers.constants.AddressZero);
         expect(
           await api3Pool.userDelegateAt(
             roles.user1.address,
             firstBlockNumber + 2
+          )
+        ).to.equal(roles.randomPerson.address);
+        expect(
+          await api3Pool.userDelegateAt(
+            roles.user1.address,
+            firstBlockNumber + 3
+          )
+        ).to.equal(ethers.constants.AddressZero);
+        expect(
+          await api3Pool.userDelegateAt(
+            roles.user1.address,
+            firstBlockNumber + 4
           )
         ).to.equal(roles.user2.address);
       });
@@ -239,7 +265,7 @@ describe("getDelegateAt", function () {
         ]);
         await api3Pool
           .connect(roles.user1)
-          .delegateVotingPower(roles.randomPerson.address);
+          .undelegateVotingPower();
         await ethers.provider.send("evm_increaseTime", [
           EPOCH_LENGTH.toNumber() + 1,
         ]);
@@ -259,7 +285,7 @@ describe("getDelegateAt", function () {
             roles.user1.address,
             initialBlockNumber + i * 2 + 2
           )
-        ).to.equal(roles.randomPerson.address);
+        ).to.equal(ethers.constants.AddressZero);
       }
     });
   });

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -193,22 +193,18 @@ describe("getDelegateAt", function () {
         const firstBlockNumber = await ethers.provider.getBlockNumber();
         // Fast forward time
         await ethers.provider.send("evm_increaseTime", [
-          EPOCH_LENGTH.toNumber(),
+          EPOCH_LENGTH.toNumber() + 1,
         ]);
         await api3Pool
           .connect(roles.user1)
           .delegateVotingPower(roles.randomPerson.address);
         // Fast forward time
         await ethers.provider.send("evm_increaseTime", [
-          EPOCH_LENGTH.toNumber(),
+          EPOCH_LENGTH.toNumber() + 1,
         ]);
         await api3Pool
           .connect(roles.user1)
           .delegateVotingPower(roles.user2.address);
-        // Fast forward time
-        await ethers.provider.send("evm_increaseTime", [
-          EPOCH_LENGTH.toNumber(),
-        ]);
         // Check delegates
         expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(
           ethers.constants.AddressZero
@@ -239,13 +235,13 @@ describe("getDelegateAt", function () {
           .connect(roles.user1)
           .delegateVotingPower(roles.user2.address);
         await ethers.provider.send("evm_increaseTime", [
-          EPOCH_LENGTH.toNumber(),
+          EPOCH_LENGTH.toNumber() + 1,
         ]);
         await api3Pool
           .connect(roles.user1)
           .delegateVotingPower(roles.randomPerson.address);
         await ethers.provider.send("evm_increaseTime", [
-          EPOCH_LENGTH.toNumber(),
+          EPOCH_LENGTH.toNumber() + 1,
         ]);
       }
       expect(await api3Pool.userDelegateAt(roles.user1.address, 0)).to.equal(


### PR DESCRIPTION
*Addresses Team Omega audit issues 1, 2*

When a user is delegated to/undelegated from, the last element of their `user.delegatedTo` gets overwritten unless there has been a new proposal made since the last update. This prevents third parties from griefing the user by delegating to them frequently and bloating their `user.delegatedTo`, which would then need to be searched through when the user attempts to vote. The issue here is that it is not only new proposals that require a checkpoint to be added to `user.delegatedTo`, but also if the delegator has voted, and this fix re-enables the said griefing (the attacker stakes 1 Wei, votes, delegates to the target and repeats this a lot of times). Since the issue is more fundamental than an off-by-one error, the recommended fix doesn't work (and enables double voting in another way).

This PR implements a fix that slightly degrades UX (within acceptable limits, assuming delegations need to be updated very infrequently), but doesn't create any additional gas cost or unpredictable side effects (because it only imposes additional restrictions):
- To prevent delegations from being used for double vote/proposal, the user is restricted from delegating if they have voted or made a proposal in the last week.
- To prevent undelegations from being used for double vote/proposal, the user is restricted from voting/making proposals if they have undelegated in the last week.
- Delegation updates (user A has delegated to B, they switch the delegation to C directly) are disabled to prevent them from being used for double vote/proposal.

Note: Unstaking can also be used for double voting. User A delegates to user B, schedules an unstaking. A proposal gets made just before the unstaking matures. User B votes with user A's voting power, user A unstakes and withdraws, stakes with another address and double votes with the same voting power. This will be resolved with the following PR ([LINK HERE]) that deducts the delegated voting power at unstaking scheduling instead of execution.