### PR TITLE
[TO-33,34,36,37,39] Update reward calculation scheme

### DIFF
--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -119,7 +119,7 @@ The Agent apps are authorized to update respective DAO parameters, and Api3Votin
 
 ## Skipped rewards
 
-User interactions call `mintReward()`, which triggers the payment for the current epoch's reward if it was not already.
+User interactions call `mintReward()`, which triggers the payment for the staking reward if it was not already.
 `mintReward()` can also be called externally, in a stand-alone way.
 If no one interacts with the pool contract in a whole week, the rewards for that week will not be paid out and the reward will not be updated.
 This is not expected to happen in practice, and will not cause any issues if it does.

--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -129,9 +129,7 @@ This is not expected to happen in practice, and will not cause any issues if it 
 If the pool not authorized to mint API3 tokens, it continues operating without paying out any rewards.
 This is to prevent the pool from breaking in case its minting authorization is revoked due to any reason.
 
-## APR update coefficient
+## APR update step
 
-This is the coefficient that represents how aggresively the APR will be updated to meet the stake target.
-Since this is a coefficient, it has no unit. A coefficient of 1,000,000 (which is the initial value) means 1% deviation from the stake target results in 1% update in APR.
-This parameter is governable by the DAO and is capped at the x1,000 the initial value.
-Misgovernance of this parameter may result in the rewards not being updated quickly enough or oscillatory rewards due to consistent overshoots.
+This is the parameter that represents how aggresively the APR will be updated to meet the stake target.
+Each epoch the total staked amount is below the target, APR will be increased by this value, and vice versa.

--- a/packages/pool/README.md
+++ b/packages/pool/README.md
@@ -119,8 +119,8 @@ The Agent apps are authorized to update respective DAO parameters, and Api3Votin
 
 ## Skipped rewards
 
-User interactions call `payReward()`, which triggers the payment for the current epoch's reward if it was not already.
-`payReward()` can also be called externally, in a stand-alone way.
+User interactions call `mintReward()`, which triggers the payment for the current epoch's reward if it was not already.
+`mintReward()` can also be called externally, in a stand-alone way.
 If no one interacts with the pool contract in a whole week, the rewards for that week will not be paid out and the reward will not be updated.
 This is not expected to happen in practice, and will not cause any issues if it does.
 

--- a/packages/pool/contracts/ClaimUtils.sol
+++ b/packages/pool/contracts/ClaimUtils.sol
@@ -29,7 +29,7 @@ abstract contract ClaimUtils is StakeUtils, IClaimUtils {
         override
         onlyClaimsManager()
     {
-        payReward();
+        mintReward();
         // totalStake should not go lower than 1
         require(totalStake > amount, ERROR_VALUE);
         totalStake = totalStake - amount;

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -12,7 +12,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         external
         override
     {
-        payReward();
+        mintReward();
         // Delegating users have cannot use their voting power, so we are
         // verifying that the delegate is not currently delegating. However,
         // the delegate may delegate after they have been delegated to.
@@ -64,7 +64,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         external
         override
     {
-        payReward();
+        mintReward();
         User storage user = users[msg.sender];
         address userDelegate = userDelegate(msg.sender);
         require(

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -45,40 +45,20 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
     function updateCurrentApr()
         internal
     {
-        if (stakeTarget == 0) {
-            currentApr = minApr;
-            return;
-        }
         uint256 totalStakePercentage = totalStake
-             * HUNDRED_PERCENT
+            * HUNDRED_PERCENT
             / api3Token.totalSupply();
-        // Calculate what % we are off from the target
-        uint256 deltaAbsolute = totalStakePercentage < stakeTarget 
-            ? stakeTarget - totalStakePercentage
-            : totalStakePercentage - stakeTarget;
-        uint256 deltaPercentage = deltaAbsolute * HUNDRED_PERCENT / stakeTarget;
-        // Use the update coefficient to calculate what % we need to update
-        // the APR with
-        uint256 aprUpdate = deltaPercentage * aprUpdateCoefficient / ONE_PERCENT;
-
-        uint256 newApr;
-        if (totalStakePercentage < stakeTarget) {
-            newApr = currentApr * (HUNDRED_PERCENT + aprUpdate) / HUNDRED_PERCENT;
+        if (totalStakePercentage > stakeTarget) {
+            currentApr = currentApr > aprUpdateStep ? currentApr - aprUpdateStep : 0;
         }
         else {
-            newApr = HUNDRED_PERCENT > aprUpdate
-                ? currentApr * (HUNDRED_PERCENT - aprUpdate) / HUNDRED_PERCENT
-                : 0;
+            currentApr += aprUpdateStep;
         }
-
-        if (newApr < minApr) {
-            currentApr = minApr;
-        }
-        else if (newApr > maxApr) {
+        if (currentApr > maxApr) {
             currentApr = maxApr;
         }
-        else {
-            currentApr = newApr;
+        else if (currentApr < minApr) {
+            currentApr = minApr;
         }
     }
 }

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -6,11 +6,11 @@ import "./interfaces/IRewardUtils.sol";
 
 /// @title Contract that implements reward payments and locks
 abstract contract RewardUtils is GetterUtils, IRewardUtils {
-    /// @notice Called to pay the reward for the current epoch
+    /// @notice Called to mint the staking reward
     /// @dev Skips past epochs for which rewards have not been paid for.
     /// Skips the reward payment if the pool is not authorized to mint tokens.
     /// Neither of these conditions will occur in practice.
-    function payReward()
+    function mintReward()
         public
         override
     {
@@ -30,7 +30,7 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
                     });
                 api3Token.mint(address(this), rewardAmount);
                 totalStake = totalStake + rewardAmount;
-                emit PaidReward(
+                emit MintedReward(
                     currentEpoch,
                     rewardAmount,
                     currentApr

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -21,7 +21,7 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
         {
             if (api3Token.getMinterStatus(address(this)))
             {
-                uint256 rewardAmount = totalStake * currentApr / REWARD_VESTING_PERIOD / HUNDRED_PERCENT;
+                uint256 rewardAmount = totalStake * currentApr * ONE_YEAR_IN_SECONDS / EPOCH_LENGTH / HUNDRED_PERCENT;
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: block.number,
                     amount: rewardAmount,

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -21,7 +21,6 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
         {
             if (api3Token.getMinterStatus(address(this)))
             {
-                updateCurrentApr();
                 uint256 rewardAmount = totalStake * currentApr / REWARD_VESTING_PERIOD / HUNDRED_PERCENT;
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: block.number,
@@ -35,13 +34,14 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
                     rewardAmount,
                     currentApr
                     );
+                updateCurrentApr();
             }
             epochIndexOfLastRewardPayment = currentEpoch;
         }
     }
 
     /// @notice Updates the current APR
-    /// @dev Called internally before paying out the reward
+    /// @dev Called internally after paying out the reward
     function updateCurrentApr()
         internal
     {

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -21,7 +21,7 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
         {
             if (api3Token.getMinterStatus(address(this)))
             {
-                uint256 rewardAmount = totalStake * currentApr * ONE_YEAR_IN_SECONDS / EPOCH_LENGTH / HUNDRED_PERCENT;
+                uint256 rewardAmount = totalStake * currentApr * EPOCH_LENGTH / ONE_YEAR_IN_SECONDS / HUNDRED_PERCENT;
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: block.number,
                     amount: rewardAmount,

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -12,7 +12,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         public
         override
     {
-        payReward();
+        mintReward();
         User storage user = users[msg.sender];
         require(user.unstaked >= amount, ERROR_VALUE);
         user.unstaked = user.unstaked - amount;
@@ -53,7 +53,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         external
         override
     {
-        payReward();
+        mintReward();
         User storage user = users[msg.sender];
         uint256 userSharesNow = userShares(msg.sender);
         uint256 userStakedNow = userSharesNow * totalStake / totalShares();
@@ -77,7 +77,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         override
         returns(uint256)
     {
-        payReward();
+        mintReward();
         User storage user = users[msg.sender];
         require(block.timestamp > user.unstakeScheduledFor, ERROR_UNAUTHORIZED);
         require(block.timestamp < user.unstakeScheduledFor + EPOCH_LENGTH, ERROR_UNAUTHORIZED);

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -64,7 +64,9 @@ contract StateUtils is IStateUtils {
     // All percentage values are represented by multiplying by 1e6
     uint256 internal constant ONE_PERCENT = 1_000_000;
     uint256 internal constant HUNDRED_PERCENT = 100_000_000;
-    
+
+    uint256 internal constant ONE_YEAR_IN_SECONDS = 52 * 7 * 24 * 60 * 60;
+
     /// @notice API3 token contract
     IApi3Token public api3Token;
 

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -17,7 +17,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         public
         override
     {
-        payReward();
+        mintReward();
         users[msg.sender].unstaked = users[msg.sender].unstaked + amount;
         // Should never return false because the API3 token uses the
         // OpenZeppelin implementation
@@ -42,7 +42,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         public
         override
     {
-        payReward();
+        mintReward();
         withdraw(destination, amount, userLocked(msg.sender));
     }
 
@@ -65,7 +65,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         returns (bool finished)
     {
         require(noEpochsPerIteration > 0, "Iteration window invalid");
-        payReward();
+        mintReward();
         Checkpoint[] storage _userShares = users[userAddress].shares;
         uint256 userSharesLength = _userShares.length;
         require(userSharesLength != 0, "User never had shares");
@@ -122,7 +122,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         external
         override
     {
-        payReward();
+        mintReward();
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[msg.sender];
         require(state.initialIndEpoch == currentEpoch, "Locked amount not precalculated");

--- a/packages/pool/contracts/interfaces/IRewardUtils.sol
+++ b/packages/pool/contracts/interfaces/IRewardUtils.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.2;
 import "./IGetterUtils.sol";
 
 interface IRewardUtils is IGetterUtils {
-    event PaidReward(
+    event MintedReward(
         uint256 indexed epoch,
         uint256 rewardAmount,
         uint256 apr
         );
 
-    function payReward()
+    function mintReward()
         external;
 }

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -34,9 +34,9 @@ interface IStateUtils {
         uint256 unstakeWaitPeriod
         );
 
-    event SetAprUpdateCoefficient(
-        uint256 oldAprUpdateCoefficient,
-        uint256 aprUpdateCoefficient
+    event SetAprUpdateStep(
+        uint256 oldAprUpdateStep,
+        uint256 aprUpdateStep
         );
 
     event SetProposalVotingPowerThreshold(
@@ -83,7 +83,7 @@ interface IStateUtils {
     function setUnstakeWaitPeriod(uint256 _unstakeWaitPeriod)
         external;
 
-    function setAprUpdateCoefficient(uint256 _aprUpdateCoefficient)
+    function setAprUpdateStep(uint256 _aprUpdateStep)
         external;
 
     function setProposalVotingPowerThreshold(uint256 _proposalVotingPowerThreshold)

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -257,9 +257,9 @@ describe("undelegateVotingPower", function () {
           expect(await api3Pool.userVotingPower(roles.user2.address)).to.equal(
             user2Stake
           );
-          expect(
-            await api3Pool.delegatedToUser(roles.user2.address)
-          ).to.equal(ethers.BigNumber.from(0));
+          expect(await api3Pool.delegatedToUser(roles.user2.address)).to.equal(
+            ethers.BigNumber.from(0)
+          );
           expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
             ethers.constants.AddressZero
           );

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -297,7 +297,7 @@ describe("userLocked", function () {
               const userStakeBefore = await api3Pool.userStake(
                 roles.user1.address
               );
-              await api3Pool.payReward();
+              await api3Pool.mintReward();
               const userStakeAfter = await api3Pool.userStake(
                 roles.user1.address
               );
@@ -328,7 +328,7 @@ describe("userLocked", function () {
             await ethers.provider.send("evm_setNextBlockTimestamp", [
               currentEpoch.mul(EPOCH_LENGTH).toNumber(),
             ]);
-            await api3Pool.payReward();
+            await api3Pool.mintReward();
           }
           const userLocked = await api3Pool.userLocked(
             roles.randomPerson.address
@@ -367,7 +367,7 @@ describe("userLocked", function () {
             const userStakeBefore = await api3Pool.userStake(
               roles.user1.address
             );
-            await api3Pool.payReward();
+            await api3Pool.mintReward();
             const userStakeAfter = await api3Pool.userStake(
               roles.user1.address
             );

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -2,10 +2,9 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
-let EPOCH_LENGTH, REWARD_VESTING_PERIOD;
-
-const onePercent = ethers.BigNumber.from("1" + "000" + "000");
-const hundredPercent = ethers.BigNumber.from("100" + "000" + "000");
+let EPOCH_LENGTH;
+const HUNDRED_PERCENT = ethers.BigNumber.from("100" + "000" + "000");
+const ONE_YEAR_IN_SECONDS = ethers.BigNumber.from(52 * 7 * 24 * 60 * 60);
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -38,15 +37,14 @@ beforeEach(async () => {
     roles.mockTimelockManager.address
   );
   EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
-  REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
 });
 
 describe("mintReward", function () {
-  context("Reward for the previous epoch has not been paid", function () {
+  context("Reward for the previous epoch has not been minted", function () {
     context("Pool contract is authorized to mint tokens", function () {
       context("Stake target is not zero", function () {
         context("Total stake is above target", function () {
-          it("updates APR and pays reward", async function () {
+          it("updates APR and mints reward", async function () {
             // Authorize pool contract to mint tokens
             await api3Token
               .connect(roles.deployer)
@@ -72,39 +70,27 @@ describe("mintReward", function () {
             const genesisEpoch = await api3Pool.genesisEpoch();
             let nextEpoch = genesisEpoch;
             // Pay rewards until APR is clipped at its minimum value
-            for (let ind = 0; ind < 5; ind++) {
+            for (let ind = 0; ind < 50; ind++) {
               nextEpoch = nextEpoch.add(ethers.BigNumber.from(1));
               await ethers.provider.send("evm_setNextBlockTimestamp", [
                 nextEpoch.mul(EPOCH_LENGTH).toNumber(),
               ]);
               // Pay reward
-              const stakeTarget = await api3Pool.stakeTarget();
               const totalStake = await api3Pool.totalStake();
-              const totalStakePercentage = totalStake
-                .mul(hundredPercent)
-                .div(await api3Token.totalSupply());
-              const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-              const deltaAbsolute = totalStakePercentage.sub(stakeTarget); // Over target
-              const deltaPercentage = deltaAbsolute
-                .mul(hundredPercent)
-                .div(stakeTarget);
-              const aprUpdate = deltaPercentage
-                .mul(aprUpdateCoefficient)
-                .div(onePercent);
+              const aprUpdateStep = await api3Pool.aprUpdateStep();
               const currentApr = await api3Pool.currentApr();
-              let newApr = currentApr
-                .mul(hundredPercent.sub(aprUpdate))
-                .div(hundredPercent);
+              let newApr = currentApr.sub(aprUpdateStep);
               if (newApr.lt(await api3Pool.minApr())) {
                 newApr = await api3Pool.minApr();
               }
               const rewardAmount = totalStake
-                .mul(newApr)
-                .div(REWARD_VESTING_PERIOD)
-                .div(hundredPercent);
+                .mul(currentApr)
+                .mul(EPOCH_LENGTH)
+                .div(ONE_YEAR_IN_SECONDS)
+                .div(HUNDRED_PERCENT);
               await expect(api3Pool.connect(roles.randomPerson).mintReward())
                 .to.emit(api3Pool, "MintedReward")
-                .withArgs(nextEpoch, rewardAmount, newApr);
+                .withArgs(nextEpoch, rewardAmount, currentApr);
               expect(await api3Pool.totalStake()).to.equal(
                 totalStake.add(rewardAmount)
               );
@@ -127,8 +113,8 @@ describe("mintReward", function () {
               .connect(roles.deployer)
               .updateMinterStatus(api3Pool.address, true);
             // Have two users stake
-            const user1Stake = ethers.utils.parseEther("10" + "000" + "000");
-            const user2Stake = ethers.utils.parseEther("30" + "000" + "000");
+            const user1Stake = ethers.utils.parseEther("1" + "000" + "000");
+            const user2Stake = ethers.utils.parseEther("3" + "000" + "000");
             await api3Token
               .connect(roles.deployer)
               .transfer(roles.user1.address, user1Stake);
@@ -145,114 +131,43 @@ describe("mintReward", function () {
             await api3Pool.connect(roles.user2).depositAndStake(user2Stake);
             // Fast forward time to one epoch into the future
             const genesisEpoch = await api3Pool.genesisEpoch();
-            const genesisEpochPlusOne = genesisEpoch.add(
-              ethers.BigNumber.from(1)
-            );
-            await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-            ]);
-            // Pay reward
-            const stakeTarget = await api3Pool.stakeTarget();
-            const totalStake = await api3Pool.totalStake();
-            const totalStakePercentage = totalStake
-              .mul(hundredPercent)
-              .div(await api3Token.totalSupply());
-            const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-            const deltaAbsolute = stakeTarget.sub(totalStakePercentage); // Under target
-            const deltaPercentage = deltaAbsolute
-              .mul(hundredPercent)
-              .div(stakeTarget);
-            const aprUpdate = deltaPercentage
-              .mul(aprUpdateCoefficient)
-              .div(onePercent);
-            const currentApr = await api3Pool.currentApr();
-            let newApr = currentApr
-              .mul(hundredPercent.add(aprUpdate))
-              .div(hundredPercent);
-            if (newApr.gt(await api3Pool.maxApr())) {
-              newApr = await api3Pool.maxApr();
+            let nextEpoch = genesisEpoch;
+            // Pay rewards until APR is clipped at its maximum value
+            for (let ind = 0; ind < 50; ind++) {
+              nextEpoch = nextEpoch.add(ethers.BigNumber.from(1));
+              await ethers.provider.send("evm_setNextBlockTimestamp", [
+                nextEpoch.mul(EPOCH_LENGTH).toNumber(),
+              ]);
+              // Pay reward
+              const totalStake = await api3Pool.totalStake();
+              const aprUpdateStep = await api3Pool.aprUpdateStep();
+              const currentApr = await api3Pool.currentApr();
+              let newApr = currentApr.add(aprUpdateStep);
+              if (newApr.gt(await api3Pool.maxApr())) {
+                newApr = await api3Pool.maxApr();
+              }
+              const rewardAmount = totalStake
+                .mul(currentApr)
+                .mul(EPOCH_LENGTH)
+                .div(ONE_YEAR_IN_SECONDS)
+                .div(HUNDRED_PERCENT);
+              await expect(api3Pool.connect(roles.randomPerson).mintReward())
+                .to.emit(api3Pool, "MintedReward")
+                .withArgs(nextEpoch, rewardAmount, currentApr);
+              expect(await api3Pool.totalStake()).to.equal(
+                totalStake.add(rewardAmount)
+              );
+              expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
+                nextEpoch
+              );
+              expect(await api3Pool.currentApr()).to.equal(newApr);
+              const reward = await api3Pool.epochIndexToReward(nextEpoch);
+              expect(reward.atBlock).to.equal(
+                await ethers.provider.getBlockNumber()
+              );
+              expect(reward.amount).to.equal(rewardAmount);
             }
-            const rewardAmount = totalStake
-              .mul(newApr)
-              .div(REWARD_VESTING_PERIOD)
-              .div(hundredPercent);
-            await expect(api3Pool.connect(roles.randomPerson).mintReward())
-              .to.emit(api3Pool, "MintedReward")
-              .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
-            expect(await api3Pool.totalStake()).to.equal(
-              totalStake.add(rewardAmount)
-            );
-            expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-              genesisEpochPlusOne
-            );
-            expect(await api3Pool.currentApr()).to.equal(newApr);
-            const reward = await api3Pool.epochIndexToReward(
-              genesisEpochPlusOne
-            );
-            expect(reward.atBlock).to.equal(
-              await ethers.provider.getBlockNumber()
-            );
-            expect(reward.amount).to.equal(rewardAmount);
           });
-        });
-      });
-      context("Stake target is zero", function () {
-        it("sets APR to minimum and pays reward", async function () {
-          // Set the stake target to zero
-          await api3Pool
-            .connect(roles.deployer)
-            .setDaoApps(
-              roles.agentAppPrimary.address,
-              roles.agentAppSecondary.address,
-              roles.votingAppPrimary.address,
-              roles.votingAppSecondary.address
-            );
-          await api3Pool
-            .connect(roles.agentAppSecondary)
-            .setStakeTarget(ethers.BigNumber.from(0));
-          // Authorize pool contract to mint tokens
-          await api3Token
-            .connect(roles.deployer)
-            .updateMinterStatus(api3Pool.address, true);
-          // Have the user stake
-          const user1Stake = ethers.utils.parseEther("20" + "000" + "000");
-          await api3Token
-            .connect(roles.deployer)
-            .transfer(roles.user1.address, user1Stake);
-          await api3Token
-            .connect(roles.user1)
-            .approve(api3Pool.address, user1Stake);
-          await api3Pool.connect(roles.user1).depositAndStake(user1Stake);
-          // Fast forward time to one epoch into the future
-          const genesisEpoch = await api3Pool.genesisEpoch();
-          const genesisEpochPlusOne = genesisEpoch.add(
-            ethers.BigNumber.from(1)
-          );
-          await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
-          ]);
-          // Pay reward
-          const totalStake = await api3Pool.totalStake();
-          const newApr = await api3Pool.minApr();
-          const rewardAmount = totalStake
-            .mul(newApr)
-            .div(REWARD_VESTING_PERIOD)
-            .div(hundredPercent);
-          await expect(api3Pool.connect(roles.randomPerson).mintReward())
-            .to.emit(api3Pool, "MintedReward")
-            .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
-          expect(await api3Pool.totalStake()).to.equal(
-            totalStake.add(rewardAmount)
-          );
-          expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
-            genesisEpochPlusOne
-          );
-          expect(await api3Pool.currentApr()).to.equal(newApr);
-          const reward = await api3Pool.epochIndexToReward(genesisEpochPlusOne);
-          expect(reward.atBlock).to.equal(
-            await ethers.provider.getBlockNumber()
-          );
-          expect(reward.amount).to.equal(rewardAmount);
         });
       });
     });
@@ -327,30 +242,18 @@ describe("mintReward", function () {
           genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
         ]);
         // Pay reward
-        const stakeTarget = await api3Pool.stakeTarget();
         const totalStake = await api3Pool.totalStake();
-        const totalStakePercentage = totalStake
-          .mul(hundredPercent)
-          .div(await api3Token.totalSupply());
-        const aprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-        const deltaAbsolute = totalStakePercentage.sub(stakeTarget); // Over target
-        const deltaPercentage = deltaAbsolute
-          .mul(hundredPercent)
-          .div(stakeTarget);
-        const aprUpdate = deltaPercentage
-          .mul(aprUpdateCoefficient)
-          .div(onePercent);
+        const aprUpdateStep = await api3Pool.aprUpdateStep();
         const currentApr = await api3Pool.currentApr();
-        const newApr = currentApr
-          .mul(hundredPercent.sub(aprUpdate))
-          .div(hundredPercent);
+        const newApr = currentApr.sub(aprUpdateStep);
         const rewardAmount = totalStake
-          .mul(newApr)
-          .div(REWARD_VESTING_PERIOD)
-          .div(hundredPercent);
+          .mul(currentApr)
+          .mul(EPOCH_LENGTH)
+          .div(ONE_YEAR_IN_SECONDS)
+          .div(HUNDRED_PERCENT);
         await expect(api3Pool.connect(roles.randomPerson).mintReward())
           .to.emit(api3Pool, "MintedReward")
-          .withArgs(genesisEpochPlusFive, rewardAmount, newApr);
+          .withArgs(genesisEpochPlusFive, rewardAmount, currentApr);
         expect(await api3Pool.totalStake()).to.equal(
           totalStake.add(rewardAmount)
         );

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -41,7 +41,7 @@ beforeEach(async () => {
   REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
 });
 
-describe("payReward", function () {
+describe("mintReward", function () {
   context("Reward for the previous epoch has not been paid", function () {
     context("Pool contract is authorized to mint tokens", function () {
       context("Stake target is not zero", function () {
@@ -102,8 +102,8 @@ describe("payReward", function () {
                 .mul(newApr)
                 .div(REWARD_VESTING_PERIOD)
                 .div(hundredPercent);
-              await expect(api3Pool.connect(roles.randomPerson).payReward())
-                .to.emit(api3Pool, "PaidReward")
+              await expect(api3Pool.connect(roles.randomPerson).mintReward())
+                .to.emit(api3Pool, "MintedReward")
                 .withArgs(nextEpoch, rewardAmount, newApr);
               expect(await api3Pool.totalStake()).to.equal(
                 totalStake.add(rewardAmount)
@@ -176,8 +176,8 @@ describe("payReward", function () {
               .mul(newApr)
               .div(REWARD_VESTING_PERIOD)
               .div(hundredPercent);
-            await expect(api3Pool.connect(roles.randomPerson).payReward())
-              .to.emit(api3Pool, "PaidReward")
+            await expect(api3Pool.connect(roles.randomPerson).mintReward())
+              .to.emit(api3Pool, "MintedReward")
               .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
             expect(await api3Pool.totalStake()).to.equal(
               totalStake.add(rewardAmount)
@@ -238,8 +238,8 @@ describe("payReward", function () {
             .mul(newApr)
             .div(REWARD_VESTING_PERIOD)
             .div(hundredPercent);
-          await expect(api3Pool.connect(roles.randomPerson).payReward())
-            .to.emit(api3Pool, "PaidReward")
+          await expect(api3Pool.connect(roles.randomPerson).mintReward())
+            .to.emit(api3Pool, "MintedReward")
             .withArgs(genesisEpochPlusOne, rewardAmount, newApr);
           expect(await api3Pool.totalStake()).to.equal(
             totalStake.add(rewardAmount)
@@ -284,7 +284,7 @@ describe("payReward", function () {
         // Pay reward
         const totalStake = await api3Pool.totalStake();
         const currentApr = await api3Pool.currentApr();
-        await api3Pool.connect(roles.randomPerson).payReward();
+        await api3Pool.connect(roles.randomPerson).mintReward();
         expect(await api3Pool.totalStake()).to.equal(totalStake);
         expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
           genesisEpochPlusOne
@@ -348,8 +348,8 @@ describe("payReward", function () {
           .mul(newApr)
           .div(REWARD_VESTING_PERIOD)
           .div(hundredPercent);
-        await expect(api3Pool.connect(roles.randomPerson).payReward())
-          .to.emit(api3Pool, "PaidReward")
+        await expect(api3Pool.connect(roles.randomPerson).mintReward())
+          .to.emit(api3Pool, "MintedReward")
           .withArgs(genesisEpochPlusFive, rewardAmount, newApr);
         expect(await api3Pool.totalStake()).to.equal(
           totalStake.add(rewardAmount)
@@ -391,7 +391,7 @@ describe("payReward", function () {
         // Pay reward
         const totalStake = await api3Pool.totalStake();
         const currentApr = await api3Pool.currentApr();
-        await api3Pool.connect(roles.randomPerson).payReward();
+        await api3Pool.connect(roles.randomPerson).mintReward();
         expect(await api3Pool.totalStake()).to.equal(totalStake);
         expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(
           genesisEpochPlusFive
@@ -433,12 +433,12 @@ describe("payReward", function () {
         genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
       ]);
       // Pay reward
-      await api3Pool.connect(roles.randomPerson).payReward();
+      await api3Pool.connect(roles.randomPerson).mintReward();
       const totalStake = await api3Pool.totalStake();
       const epochIndexOfLastRewardPayment = await api3Pool.epochIndexOfLastRewardPayment();
       const currentApr = await api3Pool.currentApr();
       // Pay reward again
-      await api3Pool.connect(roles.randomPerson).payReward();
+      await api3Pool.connect(roles.randomPerson).mintReward();
       // Nothing should have changed
       expect(await api3Pool.totalStake()).to.equal(totalStake);
       expect(await api3Pool.epochIndexOfLastRewardPayment()).to.equal(

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -63,9 +63,9 @@ describe("stake", function () {
         expect(await api3Pool.userShares(roles.user1.address)).to.equal(
           user1Stake.div(ethers.BigNumber.from(2))
         );
-        expect(
-          await api3Pool.delegatedToUser(roles.user2.address)
-        ).to.equal(user1Stake.div(ethers.BigNumber.from(2)));
+        expect(await api3Pool.delegatedToUser(roles.user2.address)).to.equal(
+          user1Stake.div(ethers.BigNumber.from(2))
+        );
         expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
           roles.user2.address
         );
@@ -87,9 +87,9 @@ describe("stake", function () {
         expect(await api3Pool.userShares(roles.user1.address)).to.equal(
           user1Stake
         );
-        expect(
-          await api3Pool.delegatedToUser(roles.user2.address)
-        ).to.equal(user1Stake);
+        expect(await api3Pool.delegatedToUser(roles.user2.address)).to.equal(
+          user1Stake
+        );
         expect(await api3Pool.userDelegate(roles.user1.address)).to.equal(
           roles.user2.address
         );
@@ -221,7 +221,7 @@ describe("unstake", function () {
               genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
             ]);
             // Unstake
-            await api3Pool.payReward();
+            await api3Pool.mintReward();
             const totalStakeNow = await api3Pool.totalStake();
             const totalStakeAfter = totalStakeNow.sub(user1Stake);
             const expectedTotalShares = totalStakeAfter
@@ -269,7 +269,7 @@ describe("unstake", function () {
               genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
             ]);
             // Unstake
-            await api3Pool.payReward();
+            await api3Pool.mintReward();
             const totalStakeNow = await api3Pool.totalStake();
             const totalStakeAfter = totalStakeNow.sub(user1Stake);
             const expectedTotalShares = totalStakeAfter

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -75,7 +75,7 @@ describe("constructor", function () {
         expect(await api3Pool.maxApr()).to.equal(
           ethers.BigNumber.from("75" + "000" + "000")
         );
-        expect(await api3Pool.aprUpdateCoefficient()).to.equal(
+        expect(await api3Pool.aprUpdateStep()).to.equal(
           ethers.BigNumber.from("1" + "000" + "000")
         );
         expect(await api3Pool.unstakeWaitPeriod()).to.equal(
@@ -84,8 +84,10 @@ describe("constructor", function () {
         expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
           ethers.BigNumber.from("100" + "000")
         );
-        // Initialize the APR at max APR
-        expect(await api3Pool.currentApr()).to.equal(await api3Pool.maxApr());
+        // Initialize the APR at (maxApr / minApr) / 2
+        expect(await api3Pool.currentApr()).to.equal(
+          (await api3Pool.maxApr()).add(await api3Pool.minApr()).div(2)
+        );
 
         // Token address set correctly
         expect(await api3Pool.api3Token()).to.equal(api3Token.address);
@@ -615,76 +617,28 @@ describe("setUnstakeWaitPeriod", function () {
   });
 });
 
-describe("setAprUpdateCoefficient", function () {
+describe("setAprUpdateStep", function () {
   context("Caller is DAO Agent", function () {
-    context(
-      "APR update coefficient to be set is larger than 0 and smaller than or equal to 1,000,000,000",
-      function () {
-        it("sets APR update coefficient", async function () {
-          await api3Pool
-            .connect(roles.deployer)
-            .setDaoApps(
-              roles.agentAppPrimary.address,
-              roles.agentAppSecondary.address,
-              roles.votingAppPrimary.address,
-              roles.votingAppSecondary.address
-            );
-          const oldAprUpdateCoefficient = await api3Pool.aprUpdateCoefficient();
-          const newAprUpdateCoefficient = ethers.BigNumber.from(
-            "50" + "000" + "000"
-          );
-          await expect(
-            api3Pool
-              .connect(roles.agentAppPrimary)
-              .setAprUpdateCoefficient(newAprUpdateCoefficient)
-          )
-            .to.emit(api3Pool, "SetAprUpdateCoefficient")
-            .withArgs(oldAprUpdateCoefficient, newAprUpdateCoefficient);
-          expect(await api3Pool.aprUpdateCoefficient()).to.equal(
-            newAprUpdateCoefficient
-          );
-          await expect(
-            api3Pool
-              .connect(roles.agentAppSecondary)
-              .setAprUpdateCoefficient(newAprUpdateCoefficient)
-          )
-            .to.emit(api3Pool, "SetAprUpdateCoefficient")
-            .withArgs(newAprUpdateCoefficient, newAprUpdateCoefficient);
-          expect(await api3Pool.aprUpdateCoefficient()).to.equal(
-            newAprUpdateCoefficient
-          );
-        });
-      }
-    );
-    context(
-      "APR update coefficient to be set is 0 or larger than 1,000,000,000",
-      function () {
-        it("reverts", async function () {
-          await api3Pool
-            .connect(roles.deployer)
-            .setDaoApps(
-              roles.agentAppPrimary.address,
-              roles.agentAppSecondary.address,
-              roles.votingAppPrimary.address,
-              roles.votingAppSecondary.address
-            );
-          const newAprUpdateCoefficient1 = ethers.BigNumber.from(0);
-          await expect(
-            api3Pool
-              .connect(roles.agentAppSecondary)
-              .setAprUpdateCoefficient(newAprUpdateCoefficient1)
-          ).to.be.revertedWith("Invalid value");
-          const newAprUpdateCoefficient2 = ethers.BigNumber.from(
-            "50" + "000" + "000" + "000"
-          );
-          await expect(
-            api3Pool
-              .connect(roles.agentAppSecondary)
-              .setAprUpdateCoefficient(newAprUpdateCoefficient2)
-          ).to.be.revertedWith("Invalid value");
-        });
-      }
-    );
+    it("sets APR update step", async function () {
+      await api3Pool
+        .connect(roles.deployer)
+        .setDaoApps(
+          roles.agentAppPrimary.address,
+          roles.agentAppSecondary.address,
+          roles.votingAppPrimary.address,
+          roles.votingAppSecondary.address
+        );
+      const oldAprUpdateStep = await api3Pool.aprUpdateStep();
+      const newAprUpdateStep = oldAprUpdateStep.div(2);
+      await expect(
+        api3Pool
+          .connect(roles.agentAppPrimary)
+          .setAprUpdateStep(newAprUpdateStep)
+      )
+        .to.emit(api3Pool, "SetAprUpdateStep")
+        .withArgs(oldAprUpdateStep, newAprUpdateStep);
+      expect(await api3Pool.aprUpdateStep()).to.equal(newAprUpdateStep);
+    });
   });
   context("Caller is not DAO Agent", function () {
     it("reverts", async function () {
@@ -692,7 +646,7 @@ describe("setAprUpdateCoefficient", function () {
       await expect(
         api3Pool
           .connect(roles.randomPerson)
-          .setAprUpdateCoefficient(newAprUpdateCoefficient)
+          .setAprUpdateStep(newAprUpdateCoefficient)
       ).to.be.revertedWith("Unauthorized");
     });
   });

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -78,7 +78,7 @@ describe("withdrawRegular", function () {
         await ethers.provider.send("evm_setNextBlockTimestamp", [
           currentEpoch.mul(EPOCH_LENGTH).toNumber(),
         ]);
-        await api3Pool.payReward();
+        await api3Pool.mintReward();
       }
       // Schedule unstake and execute
       await api3Pool
@@ -159,7 +159,7 @@ describe("precalculateUserLocked", function () {
             await ethers.provider.send("evm_setNextBlockTimestamp", [
               currentEpoch.mul(EPOCH_LENGTH).toNumber(),
             ]);
-            await api3Pool.payReward();
+            await api3Pool.mintReward();
           }
           const userLocked = await api3Pool.userLocked(roles.user1.address);
           const noEpochsToCalculateLockedForAtEachIteration = 10;
@@ -253,7 +253,7 @@ describe("withdrawPrecalculated", function () {
         await ethers.provider.send("evm_setNextBlockTimestamp", [
           currentEpoch.mul(EPOCH_LENGTH).toNumber(),
         ]);
-        await api3Pool.payReward();
+        await api3Pool.mintReward();
       }
       // Schedule unstake and execute
       await api3Pool


### PR DESCRIPTION
- TO issue 33
In the documentation, "current epoch's rewards" was used to refer to rewards paid in the current epoch. TO thinks it should refer to rewards paid to people staked in the current epoch. References to current-ness is avoided to resolve the ambiguity.
- TO issue 34
APR is updated after the reward payout as recommended
- TO issue 36
Switched from a PID-controlled reward calculation model to the simpler Livepeer model
- TO issue 37
Resolved by changing the reward calculation model (note that the formula suggested in the audit report is not correct, the correct version is implemented)
- TO issue 37
Resolved by parameterizing the reward calculation