### PR TITLE
[TO-44] Deduct user shares while scheduling unstake

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -256,9 +256,17 @@ contract Api3Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
-        (, , , , , uint256 mostRecentProposalTimestamp) = api3Pool.getUser(msg.sender);
-        require(mostRecentProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
-        api3Pool.updateMostRecentProposalTimestamp(msg.sender);
+        (
+            , // unstaked
+            , // vesting
+            , // unstakeShares
+            , // unstakeAmount
+            , // unstakeScheduledFor
+            , // lastDelegationUpdateTimestamp
+            uint256 lastProposalTimestamp
+            ) = api3Pool.getUser(msg.sender);
+        require(lastProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
+        api3Pool.updateLastProposalTimestamp(msg.sender);
 
         uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
 

--- a/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
+++ b/packages/api3-voting/contracts/interfaces/IApi3Pool.sol
@@ -25,7 +25,7 @@ interface IApi3Pool {
         view
         returns(uint256);
 
-    function updateMostRecentProposalTimestamp(address userAddress)
+    function updateLastProposalTimestamp(address userAddress)
         external;
 
     function getUser(address userAddress)
@@ -34,9 +34,10 @@ interface IApi3Pool {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 unstakeScheduledFor,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 lastProposalTimestamp
             );
 }

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -67,21 +67,17 @@ contract Api3TokenMock is MiniMeToken {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 unstakeScheduledFor,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 lastProposalTimestamp
             )
     {
-        unstaked = 0;
-        vesting = 0;
-        lastDelegationUpdateTimestamp = 0;
-        unstakeScheduledFor = 0;
-        unstakeAmount = 0;
-        mostRecentProposalTimestamp = 0;
+        // Return all zeros
     }
 
-    function updateMostRecentProposalTimestamp(address userAddress)
+    function updateLastProposalTimestamp(address userAddress)
         external
     {
     }

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -207,11 +207,11 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
     /// @param userAddress User address
     /// @return unstaked Amount of unstaked API3 tokens
     /// @return vesting Amount of API3 tokens locked by vesting
-    /// @return lastDelegationUpdateTimestamp Time of most recent delegation
-    /// update
-    /// @return unstakeScheduledFor Time unstaking is scheduled for
+    /// @return unstakeShares Shares revoked to unstake
     /// @return unstakeAmount Amount scheduled to unstake
-    /// @return mostRecentProposalTimestamp Time when the user made their most
+    /// @return unstakeScheduledFor Time unstaking is scheduled for
+    /// @return lastDelegationUpdateTimestamp Time of last delegation update
+    /// @return lastProposalTimestamp Time when the user made their most
     /// recent proposal
     function getUser(address userAddress)
         external
@@ -220,19 +220,21 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns (
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
-        )
+            uint256 unstakeScheduledFor,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 lastProposalTimestamp
+            )
     {
         User storage user = users[userAddress];
         unstaked = user.unstaked;
         vesting = user.vesting;
-        lastDelegationUpdateTimestamp = user.lastDelegationUpdateTimestamp;
-        unstakeScheduledFor = user.unstakeScheduledFor;
+        unstakeShares = user.unstakeShares;
         unstakeAmount = user.unstakeAmount;
-        mostRecentProposalTimestamp = user.mostRecentProposalTimestamp;
+        unstakeScheduledFor = user.unstakeScheduledFor;
+        lastDelegationUpdateTimestamp = user.lastDelegationUpdateTimestamp;
+        lastProposalTimestamp = user.lastProposalTimestamp;
     }
 
     /// @notice Called to get the value of a checkpoint array at a specific

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -23,15 +23,16 @@ contract StateUtils is IStateUtils {
     }
 
     struct User {
-        uint256 unstaked;
-        uint256 vesting;
         Checkpoint[] shares;
         AddressCheckpoint[] delegates;
         Checkpoint[] delegatedTo;
-        uint256 lastDelegationUpdateTimestamp;
-        uint256 unstakeScheduledFor;
+        uint256 unstaked;
+        uint256 vesting;
+        uint256 unstakeShares;
         uint256 unstakeAmount;
-        uint256 mostRecentProposalTimestamp;
+        uint256 unstakeScheduledFor;
+        uint256 lastDelegationUpdateTimestamp;
+        uint256 lastProposalTimestamp;
     }
 
     struct LockedCalculationState {
@@ -423,15 +424,15 @@ contract StateUtils is IStateUtils {
     }
 
     /// @notice Called by a DAO Api3Voting app at proposal creation-time to
-    /// update the timestamp of the user's most recent proposal
+    /// update the timestamp of the user's last proposal
     /// @param userAddress User address
-    function updateMostRecentProposalTimestamp(address userAddress)
+    function updateLastProposalTimestamp(address userAddress)
         external
         override
         onlyVotingApp()
     {
-        users[userAddress].mostRecentProposalTimestamp = block.timestamp;
-        emit UpdatedMostRecentProposalTimestamp(
+        users[userAddress].lastProposalTimestamp = block.timestamp;
+        emit UpdatedLastProposalTimestamp(
             msg.sender,
             userAddress,
             block.timestamp

--- a/packages/pool/contracts/interfaces/IGetterUtils.sol
+++ b/packages/pool/contracts/interfaces/IGetterUtils.sol
@@ -82,9 +82,10 @@ interface IGetterUtils is IStateUtils {
         returns(
             uint256 unstaked,
             uint256 vesting,
-            uint256 lastDelegationUpdateTimestamp,
-            uint256 unstakeScheduledFor,
+            uint256 unstakeShares,
             uint256 unstakeAmount,
-            uint256 mostRecentProposalTimestamp
+            uint256 unstakeScheduledFor,
+            uint256 lastDelegationUpdateTimestamp,
+            uint256 lastProposalTimestamp
             );
 }

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -12,14 +12,14 @@ interface IStakeUtils is ITransferUtils{
 
     event ScheduledUnstake(
         address indexed user,
+        uint256 shares,
         uint256 amount,
         uint256 scheduledFor
         );
 
     event Unstaked(
         address indexed user,
-        uint256 amount,
-        uint256 totalShares
+        uint256 amount
         );
 
     function stake(uint256 amount)
@@ -31,9 +31,9 @@ interface IStakeUtils is ITransferUtils{
     function scheduleUnstake(uint256 amount)
         external;
 
-    function unstake()
+    function unstake(address userAddress)
         external
-        returns(uint256);
+        returns (uint256);
 
     function unstakeAndWithdraw(address destination)
         external;

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -51,10 +51,10 @@ interface IStateUtils {
         string specsUrl
         );
 
-    event UpdatedMostRecentProposalTimestamp(
+    event UpdatedLastProposalTimestamp(
         address votingApp,
         address userAddress,
-        uint256 mostRecentProposalTimestamp
+        uint256 lastProposalTimestamp
         );
 
     function setDaoApps(
@@ -96,6 +96,6 @@ interface IStateUtils {
         )
         external;
 
-    function updateMostRecentProposalTimestamp(address userAddress)
+    function updateLastProposalTimestamp(address userAddress)
         external;
 }

--- a/packages/pool/contracts/mock/MockApi3Voting.sol
+++ b/packages/pool/contracts/mock/MockApi3Voting.sol
@@ -14,6 +14,6 @@ contract MockApi3Voting {
     function newVote(address userAddress)
         external
     {
-        api3Pool.updateMostRecentProposalTimestamp(userAddress);
+        api3Pool.updateLastProposalTimestamp(userAddress);
     }
 }

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -461,8 +461,6 @@ describe("getUser", function () {
     );
     expect(user.unstakeScheduledFor).to.equal(unstakeScheduledFor);
     expect(user.unstakeAmount).to.equal(userScheduledToUnstake);
-    expect(user.lastProposalTimestamp).to.equal(
-      proposalBlock.timestamp + 100
-    );
+    expect(user.lastProposalTimestamp).to.equal(proposalBlock.timestamp + 100);
   });
 });

--- a/packages/pool/test/GetterUtils.sol.js
+++ b/packages/pool/test/GetterUtils.sol.js
@@ -461,7 +461,7 @@ describe("getUser", function () {
     );
     expect(user.unstakeScheduledFor).to.equal(unstakeScheduledFor);
     expect(user.unstakeAmount).to.equal(userScheduledToUnstake);
-    expect(user.mostRecentProposalTimestamp).to.equal(
+    expect(user.lastProposalTimestamp).to.equal(
       proposalBlock.timestamp + 100
     );
   });

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -789,9 +789,9 @@ describe("publishSpecsUrl", function () {
   });
 });
 
-describe("updateMostRecentProposalTimestamp", function () {
+describe("updateLastProposalTimestamp", function () {
   context("Caller is a Voting app", function () {
-    it("updates mostRecentProposalTimestamp", async function () {
+    it("updates lastProposalTimestamp", async function () {
       await api3Pool
         .connect(roles.deployer)
         .setDaoApps(
@@ -810,9 +810,9 @@ describe("updateMostRecentProposalTimestamp", function () {
       await expect(
         api3Pool
           .connect(roles.votingAppPrimary)
-          .updateMostRecentProposalTimestamp(roles.user1.address)
+          .updateLastProposalTimestamp(roles.user1.address)
       )
-        .to.emit(api3Pool, "UpdatedMostRecentProposalTimestamp")
+        .to.emit(api3Pool, "UpdatedLastProposalTimestamp")
         .withArgs(
           roles.votingAppPrimary.address,
           roles.user1.address,
@@ -820,7 +820,7 @@ describe("updateMostRecentProposalTimestamp", function () {
         );
       expect(
         (await api3Pool.getUser(roles.user1.address))
-          .mostRecentProposalTimestamp
+          .lastProposalTimestamp
       ).to.equal(nextBlockTimestamp);
     });
   });
@@ -837,7 +837,7 @@ describe("updateMostRecentProposalTimestamp", function () {
       await expect(
         api3Pool
           .connect(roles.randomPerson)
-          .updateMostRecentProposalTimestamp(roles.user1.address)
+          .updateLastProposalTimestamp(roles.user1.address)
       ).to.be.revertedWith("Unauthorized");
     });
   });

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -819,8 +819,7 @@ describe("updateLastProposalTimestamp", function () {
           nextBlockTimestamp
         );
       expect(
-        (await api3Pool.getUser(roles.user1.address))
-          .lastProposalTimestamp
+        (await api3Pool.getUser(roles.user1.address)).lastProposalTimestamp
       ).to.equal(nextBlockTimestamp);
     });
   });

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -83,11 +83,11 @@ describe("withdrawRegular", function () {
       // Schedule unstake and execute
       await api3Pool
         .connect(roles.user1)
-        .scheduleUnstake(await api3Pool.userStake(roles.user1.address));
+        .scheduleUnstake(await api3Pool.userShares(roles.user1.address));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
         genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
       ]);
-      await api3Pool.connect(roles.user1).unstake();
+      await api3Pool.connect(roles.randomPerson).unstake(roles.user1.address);
       const userBefore = await api3Pool.users(roles.user1.address);
       const unlocked = userBefore.unstaked.sub(
         await api3Pool.userLocked(roles.user1.address)
@@ -258,11 +258,11 @@ describe("withdrawPrecalculated", function () {
       // Schedule unstake and execute
       await api3Pool
         .connect(roles.user1)
-        .scheduleUnstake(await api3Pool.userStake(roles.user1.address));
+        .scheduleUnstake(await api3Pool.userShares(roles.user1.address));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
         genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
       ]);
-      await api3Pool.connect(roles.user1).unstake();
+      await api3Pool.connect(roles.randomPerson).unstake(roles.user1.address);
       await api3Pool
         .connect(roles.user1)
         .precalculateUserLocked(


### PR DESCRIPTION
User shares are deducted while scheduling the unstake, which the shares are deducted from the pool while executing the unstake. This means that the user will no longer get rewards/voting power from these tokens, yet they will be subjected to slashing in the event of a claim payout.
Two additional changes were made to complement this:
- Any user can execute a scheduled and matured unstake
- A user that has scheduled an unstake cannot scheduled another one before executing the active one


