### PR TITLE
[TO-4] Consolidate percentage convention

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -274,7 +274,7 @@ contract Api3Voting is IForwarder, AragonApp {
         require(votingPower > 0, ERROR_NO_VOTING_POWER);
         uint256 proposalMakerVotingPower = api3Pool.userVotingPowerAt(msg.sender, snapshotBlock);
         require(
-            proposalMakerVotingPower >= votingPower.mul(api3Pool.proposalVotingPowerThreshold()).div(1e8),
+            proposalMakerVotingPower >= votingPower.mul(api3Pool.proposalVotingPowerThreshold()).div(PCT_BASE),
             "API3_HIT_PROPOSAL_THRESHOLD"
             );
 

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -63,8 +63,8 @@ contract StateUtils is IStateUtils {
     string internal constant ERROR_DELEGATE = "Cannot delegate to the same address";
 
     // All percentage values are represented by multiplying by 1e6
-    uint256 internal constant ONE_PERCENT = 1_000_000;
-    uint256 internal constant HUNDRED_PERCENT = 100_000_000;
+    uint256 internal constant ONE_PERCENT = 1e18 / 100;
+    uint256 internal constant HUNDRED_PERCENT = 1e18;
 
     uint256 internal constant ONE_YEAR_IN_SECONDS = 52 * 7 * 24 * 60 * 60;
 
@@ -124,21 +124,21 @@ contract StateUtils is IStateUtils {
     /// amount is below this, and vice versa.
     /// @dev Default value is 50% of the total API3 token supply. This
     /// parameter is governable by the DAO.
-    uint256 public stakeTarget = 50_000_000;
+    uint256 public stakeTarget = 50 * ONE_PERCENT;
 
     /// @notice Minimum APR (annual percentage rate) the pool will pay as
     /// staking rewards in percentages
     /// @dev Default value is 2.5%. This parameter is governable by the DAO.
-    uint256 public minApr = 2_500_000;
+    uint256 public minApr = ONE_PERCENT * 25 / 10;
 
     /// @notice Maximum APR (annual percentage rate) the pool will pay as
     /// staking rewards in percentages
     /// @dev Default value is 75%. This parameter is governable by the DAO.
-    uint256 public maxApr = 75_000_000;
+    uint256 public maxApr = 75 * ONE_PERCENT;
 
     /// @notice Steps in which APR will be updated in percentages
     /// @dev Default value is 1%. This parameter is governable by the DAO.
-    uint256 public aprUpdateStep = 1_000_000;
+    uint256 public aprUpdateStep = ONE_PERCENT;
 
     /// @notice Users need to schedule an unstake and wait for
     /// `unstakeWaitPeriod` before being able to unstake. This is to prevent
@@ -154,7 +154,7 @@ contract StateUtils is IStateUtils {
     /// proposals (in percentages)
     /// @dev Delegations count towards voting power.
     /// Default value is 0.1%. This parameter is governable by the DAO.
-    uint256 public proposalVotingPowerThreshold = 100_000;
+    uint256 public proposalVotingPowerThreshold = ONE_PERCENT / 10;
 
     /// @notice APR that will be paid next epoch
     /// @dev This value will reach an equilibrium based on the stake target.

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -3,7 +3,7 @@ const { expect } = require("chai");
 let roles;
 let api3Token, api3Pool;
 let EPOCH_LENGTH;
-const HUNDRED_PERCENT = ethers.BigNumber.from("100" + "000" + "000");
+const HUNDRED_PERCENT = ethers.BigNumber.from(`1${"0".repeat(18)}`);
 const ONE_YEAR_IN_SECONDS = ethers.BigNumber.from(52 * 7 * 24 * 60 * 60);
 
 beforeEach(async () => {

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -67,22 +67,22 @@ describe("constructor", function () {
 
         // Verify the default DAO parameters
         expect(await api3Pool.stakeTarget()).to.equal(
-          ethers.BigNumber.from("50" + "000" + "000")
+          ethers.BigNumber.from(`50${"0".repeat(16)}`)
         );
         expect(await api3Pool.minApr()).to.equal(
-          ethers.BigNumber.from("2" + "500" + "000")
+          ethers.BigNumber.from(`25${"0".repeat(15)}`)
         );
         expect(await api3Pool.maxApr()).to.equal(
-          ethers.BigNumber.from("75" + "000" + "000")
+          ethers.BigNumber.from(`75${"0".repeat(16)}`)
         );
         expect(await api3Pool.aprUpdateStep()).to.equal(
-          ethers.BigNumber.from("1" + "000" + "000")
+          ethers.BigNumber.from(`1${"0".repeat(16)}`)
         );
         expect(await api3Pool.unstakeWaitPeriod()).to.equal(
           await api3Pool.EPOCH_LENGTH()
         );
         expect(await api3Pool.proposalVotingPowerThreshold()).to.equal(
-          ethers.BigNumber.from("100" + "000")
+          ethers.BigNumber.from(`1${"0".repeat(15)}`)
         );
         // Initialize the APR at (maxApr / minApr) / 2
         expect(await api3Pool.currentApr()).to.equal(
@@ -362,7 +362,7 @@ describe("setClaimsManagerStatus", function () {
 describe("setStakeTarget", function () {
   context("Caller is Agent", function () {
     context(
-      "Stake target to be set is smaller than or equal to 100,000,000",
+      "Stake target to be set is smaller than or equal to 100%",
       function () {
         it("sets stake target", async function () {
           await api3Pool
@@ -394,7 +394,7 @@ describe("setStakeTarget", function () {
         });
       }
     );
-    context("Stake target to be set is larger than 100,000,000", function () {
+    context("Stake target to be set is larger than 100%", function () {
       it("reverts", async function () {
         await api3Pool
           .connect(roles.deployer)
@@ -404,7 +404,7 @@ describe("setStakeTarget", function () {
             roles.votingAppPrimary.address,
             roles.votingAppSecondary.address
           );
-        const newStakeTarget = ethers.BigNumber.from("200" + "000" + "000");
+        const newStakeTarget = ethers.BigNumber.from(`200${"0".repeat(16)}`);
         await expect(
           api3Pool
             .connect(roles.agentAppSecondary)
@@ -655,7 +655,7 @@ describe("setAprUpdateStep", function () {
 describe("setProposalVotingPowerThreshold", function () {
   context("Caller is primary DAO Agent", function () {
     context(
-      "Proposal voting power threshold to be set is between 100,000 (0.1%) and 10,000,000 (10%)",
+      "Proposal voting power threshold to be set is between 0.1% and 10%",
       function () {
         it("sets proposal voting power threshold", async function () {
           await api3Pool
@@ -668,7 +668,7 @@ describe("setProposalVotingPowerThreshold", function () {
             );
           const oldProposalVotingPowerThreshold = await api3Pool.proposalVotingPowerThreshold();
           const firstNewProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "10" + "000" + "000"
+            `10${"0".repeat(16)}`
           );
           await expect(
             api3Pool
@@ -686,7 +686,7 @@ describe("setProposalVotingPowerThreshold", function () {
             firstNewProposalVotingPowerThreshold
           );
           const secondNewProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "100" + "000"
+            `1${"0".repeat(15)}`
           );
           await expect(
             api3Pool
@@ -719,7 +719,7 @@ describe("setProposalVotingPowerThreshold", function () {
               roles.votingAppSecondary.address
             );
           const firstNewProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "10" + "000" + "000"
+            `10${"0".repeat(16)}`
           ).add(ethers.BigNumber.from(1));
           await expect(
             api3Pool
@@ -729,7 +729,7 @@ describe("setProposalVotingPowerThreshold", function () {
               )
           ).to.be.revertedWith("Invalid value");
           const secondNewProposalVotingPowerThreshold = ethers.BigNumber.from(
-            "100" + "000"
+            `1${"0".repeat(15)}`
           ).sub(ethers.BigNumber.from(1));
           await expect(
             api3Pool


### PR DESCRIPTION
Same percentage convention is used in all contracts (`1e18 = 100%`)