### PR TITLE
[TO-10,15,19] Minor Api3Voting fixes

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -397,7 +397,7 @@ contract Api3Voting is IForwarder, AragonApp {
             return false;
         }
 
-        uint256 computedPct = _value.mul(PCT_BASE) / _total;
+        uint256 computedPct = _value.mul(PCT_BASE).div(_total);
         return computedPct > _pct;
     }
 }

--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -71,17 +71,15 @@ contract Api3Voting is IForwarder, AragonApp {
     }
 
     /**
-    * @notice Initialize Voting app with `_token.symbol(): string` for governance, minimum support of `@formatPct(_supportRequiredPct)`%, minimum acceptance quorum of `@formatPct(_minAcceptQuorumPct)`%, and a voting duration of `@transformTime(_voteTime)`
+    * @notice Initialize Voting app with `_token.symbol(): string` for governance, minimum support of `@formatPct(_supportRequiredPct)`%, minimum acceptance quorum of `@formatPct(_minAcceptQuorumPct)`%`
     * @param _token MiniMeToken Address that will be used as governance token
     * @param _supportRequiredPct Percentage of yeas in casted votes for a vote to succeed (expressed as a percentage of 10^18; eg. 10^16 = 1%, 10^18 = 100%)
     * @param _minAcceptQuorumPct Percentage of yeas in total possible votes for a vote to succeed (expressed as a percentage of 10^18; eg. 10^16 = 1%, 10^18 = 100%)
-    * @param _voteTime Seconds that a vote will be open for token holders to vote (unless enough yeas or nays have been cast to make an early decision)
     */
     function initialize(
         address _token,
         uint64 _supportRequiredPct,
-        uint64 _minAcceptQuorumPct,
-        uint64 _voteTime
+        uint64 _minAcceptQuorumPct
     )
         external
         onlyInit
@@ -93,9 +91,10 @@ contract Api3Voting is IForwarder, AragonApp {
 
         supportRequiredPct = _supportRequiredPct;
         minAcceptQuorumPct = _minAcceptQuorumPct;
-        voteTime = _voteTime;
         // The pool acts as the MiniMe token
         api3Pool = IApi3Pool(_token);
+        // Unlike the original Voting app, `voteTime` has to be `EPOCH_LENGTH` of the pool
+        voteTime = uint64(api3Pool.EPOCH_LENGTH());
     }
 
     /**

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -26,7 +26,7 @@ contract Api3TokenMock is MiniMeToken {
     {
     }
 
-    uint256 private mockEPOCH_LENGTH = 0;
+    uint256 public EPOCH_LENGTH = 7 * 24 * 60 * 60;
     uint256 private mockProposalVotingPowerThreshold = 0;
 
     function userVotingPowerAt(address userAddress, uint256 _block)
@@ -35,14 +35,6 @@ contract Api3TokenMock is MiniMeToken {
         returns (uint)
     {
         return balanceOfAt(userAddress, _block);
-    }
-
-    function EPOCH_LENGTH()
-        external
-        view
-        returns(uint256)
-    {
-        return mockEPOCH_LENGTH;
     }
 
     function proposalVotingPowerThreshold()

--- a/packages/api3-voting/test/delegation-integration.js_
+++ b/packages/api3-voting/test/delegation-integration.js_
@@ -21,7 +21,6 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
     let CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE, ERROR_ADDRESS, ERROR_ANAUTHORISED;
 
     const NOW = 1;
-    const votingDuration = 1000;
     const APP_ID = '0x1234123412341234123412341234123412341234123412341234123412341234';
 
     before('Create token, pool and voting', async () => {
@@ -85,7 +84,7 @@ contract('API3 Voting App delegation tests', ([root, voter1, voter2, voter3, non
             await pool.delegateVotingPower(voter2, {from: voter1});
             const neededSupport = pct16(60);
             const minimumAcceptanceQuorum = pct16(20);
-            await voting.initialize(pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration);
+            await voting.initialize(pool.address, neededSupport, minimumAcceptanceQuorum);
             const voteId = createdVoteId(await voting.newVote(EMPTY_CALLS_SCRIPT, 'metadata', {from: voter3}));
             await voting.vote(voteId, true, false, { from: voter2 });
             const result = await voting.getVote(voteId);

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -23,7 +23,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
   let CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE;
 
   const NOW = 1;
-  const votingDuration = 1000;
+  const votingDuration = 7 * 24 * 60 * 60;
   const APP_ID = '0x1234123412341234123412341234123412341234123412341234123412341234';
 
   before('load roles', async () => {
@@ -51,18 +51,18 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       api3Pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
       await api3Pool.setDaoApps(voting.address, voting.address, voting.address, voting.address);
 
-      await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration);
+      await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum);
       executionTarget = await ExecutionTarget.new()
     });
 
     it('fails on reinitialization', async () => {
-      await assertRevert(voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration), ERRORS.INIT_ALREADY_INITIALIZED)
+      await assertRevert(voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum), ERRORS.INIT_ALREADY_INITIALIZED)
     });
 
     it('cannot initialize base app', async () => {
       const newVoting = await Voting.new();
       assert.isTrue(await newVoting.isPetrified());
-      await assertRevert(newVoting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration), ERRORS.INIT_ALREADY_INITIALIZED)
+      await assertRevert(newVoting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum), ERRORS.INIT_ALREADY_INITIALIZED)
     });
 
     it('checks it is forwarder', async () => {
@@ -114,7 +114,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
         await token.generateTokens(holder29, bigExp(29, decimals));
         await token.generateTokens(holder51, bigExp(51, decimals));
 
-        await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum, votingDuration);
+        await voting.initialize(api3Pool.address, neededSupport, minimumAcceptanceQuorum);
 
         // holder 51 deposit and stake
         await token.approve(api3Pool.address, bigExp(51, decimals), {from:holder51});
@@ -327,13 +327,13 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
     it('fails if min acceptance quorum is greater than min support', async () => {
       const neededSupport = pct16(20);
       const minimumAcceptanceQuorum = pct16(50);
-      await assertRevert(voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration), ERRORS.VOTING_INIT_PCTS)
+      await assertRevert(voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum), ERRORS.VOTING_INIT_PCTS)
     });
 
     it('fails if min support is 100% or more', async () => {
       const minimumAcceptanceQuorum = pct16(20);
-      await assertRevert(voting.initialize(token.address, pct16(101), minimumAcceptanceQuorum, votingDuration), ERRORS.VOTING_INIT_SUPPORT_TOO_BIG);
-      await assertRevert(voting.initialize(token.address, pct16(100), minimumAcceptanceQuorum, votingDuration), ERRORS.VOTING_INIT_SUPPORT_TOO_BIG)
+      await assertRevert(voting.initialize(token.address, pct16(101), minimumAcceptanceQuorum), ERRORS.VOTING_INIT_SUPPORT_TOO_BIG);
+      await assertRevert(voting.initialize(token.address, pct16(100), minimumAcceptanceQuorum), ERRORS.VOTING_INIT_SUPPORT_TOO_BIG)
     })
   });
 
@@ -344,7 +344,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
     beforeEach(async() => {
       token = await Api3TokenMock.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true); // empty parameters minime
 
-      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration)
+      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum)
     });
 
     it('fails creating a vote if token has no holder', async () => {
@@ -361,7 +361,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
 
       await token.generateTokens(holder1, 1);
 
-      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration)
+      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum)
     });
 
     it('new vote cannot be executed before voting', async () => {
@@ -407,7 +407,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       await token.generateTokens(holder1, 1);
       await token.generateTokens(holder2, 2);
 
-      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration)
+      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum)
     });
 
     it('new vote cannot be executed before holder2 voting', async () => {
@@ -442,7 +442,7 @@ contract('API3 Voting App', ([root, holder1, holder2, holder20, holder29, holder
       await token.generateTokens(holder1, 1);
       await token.generateTokens(holder2, 1);
 
-      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration)
+      await voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum)
     });
 
     it('uses the correct snapshot value if tokens are minted afterwards', async () => {

--- a/packages/dao/contracts/Api3Template.sol
+++ b/packages/dao/contracts/Api3Template.sol
@@ -48,12 +48,12 @@ contract Api3Template is BaseTemplate {
     * @param _secondaryVotingSettings Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization
     */
     function newInstance(
-        string memory _id,
+        string _id,
         MiniMeToken _api3Pool,
-        uint64[3] memory _mainVotingSettings,
-        uint64[3] memory _secondaryVotingSettings
+        uint64[3] _mainVotingSettings,
+        uint64[3] _secondaryVotingSettings
     )
-    public
+    external
     {
         require(_api3Pool != address(0), "Invalid API3 Api3Voting Rights");
 

--- a/packages/dao/contracts/Api3Template.sol
+++ b/packages/dao/contracts/Api3Template.sol
@@ -44,14 +44,14 @@ contract Api3Template is BaseTemplate {
     * @dev Deploy an authoritative DAO using the API3 Staking Pool
     * @param _id String with the name for org, will assign `[id].aragonid.eth`
     * @param _api3Pool Address of the API3 staking pool, supplies voting power
-    * @param _mainVotingSettings Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization
-    * @param _secondaryVotingSettings Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization
+    * @param _mainVotingSettings Array of [supportRequired, minAcceptanceQuorum] to set up the voting app of the organization
+    * @param _secondaryVotingSettings Array of [supportRequired, minAcceptanceQuorum] to set up the voting app of the organization
     */
     function newInstance(
         string _id,
         MiniMeToken _api3Pool,
-        uint64[3] _mainVotingSettings,
-        uint64[3] _secondaryVotingSettings
+        uint64[2] _mainVotingSettings,
+        uint64[2] _secondaryVotingSettings
     )
     external
     {
@@ -83,8 +83,8 @@ contract Api3Template is BaseTemplate {
         Kernel _dao,
         ACL _acl,
         MiniMeToken _api3Pool,
-        uint64[3] memory _mainVotingSettings,
-        uint64[3] memory _secondaryVotingSettings
+        uint64[2] memory _mainVotingSettings,
+        uint64[2] memory _secondaryVotingSettings
     )
     internal
     returns (Api3Voting, Api3Voting, Agent, Agent)
@@ -125,26 +125,25 @@ contract Api3Template is BaseTemplate {
         _createApi3VotingPermissions(_acl, _secondaryVoting, _mainAgent, ANY_ENTITY, _permissionManager);
     }
 
-    function _validateVotingSettings(uint64[3] memory _votingSettings) private pure {
-        require(_votingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);
+    function _validateVotingSettings(uint64[2] memory _votingSettings) private pure {
+        require(_votingSettings.length == 2, ERROR_BAD_VOTE_SETTINGS);
     }
 
     /*API3 VOTING*/
 
-    function _installApi3VotingApp(Kernel _dao, MiniMeToken _token, uint64[3] memory _votingSettings) internal returns (Api3Voting) {
-        return _installApi3VotingApp(_dao, _token, _votingSettings[0], _votingSettings[1], _votingSettings[2]);
+    function _installApi3VotingApp(Kernel _dao, MiniMeToken _token, uint64[2] memory _votingSettings) internal returns (Api3Voting) {
+        return _installApi3VotingApp(_dao, _token, _votingSettings[0], _votingSettings[1]);
     }
 
     function _installApi3VotingApp(
         Kernel _dao,
         MiniMeToken _token,
         uint64 _support,
-        uint64 _acceptance,
-        uint64 _duration
+        uint64 _acceptance
     )
     internal returns (Api3Voting)
     {
-        bytes memory initializeData = abi.encodeWithSelector(Api3Voting(0).initialize.selector, _token, _support, _acceptance, _duration);
+        bytes memory initializeData = abi.encodeWithSelector(Api3Voting(0).initialize.selector, _token, _support, _acceptance);
         return Api3Voting(_installNonDefaultApp(_dao, API3_VOTING_APP_ID, initializeData));
     }
 

--- a/packages/dao/test/api3template.js
+++ b/packages/dao/test/api3template.js
@@ -23,11 +23,11 @@ contract('Api3Template', ([_, deployer, tokenAddress, authorized]) => { // eslin
 
   const SUPPORT_1 = 80e16;
   const ACCEPTANCE_1 = 40e16;
-  const VOTING_DURATION_1 = 100;
+  const VOTING_DURATION_1 = 7 * 24 * 60 * 60;
 
   const SUPPORT_2 = 50e16;
   const ACCEPTANCE_2 = 20e16;
-  const VOTING_DURATION_2 = 60;
+  const VOTING_DURATION_2 = 7 * 24 * 60 * 60;
 
   before('fetch bare template', async () => {
     api3Template = Api3Template.at(await getTemplateAddress())


### PR DESCRIPTION
- TO issue 10
Used SafeMath for the division in Api3Voting.sol
- TO issue 15
Made `newInstance()` in Api3Template.sol external
- TO issue 19
`voteTime` of the Api3Voting apps were supposed to be set as `EPOCH_LENGTH` from pool, but this was not obvious to TO. This is now hardcoded (fetched from Api3Pool at initialization)