### PR TITLE
Prevent genesis proposals

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -255,6 +255,7 @@ contract Api3Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
+        require(!api3Pool.isGenesisEpoch(), "API3_GENESIS_EPOCH");
         (
             , // unstaked
             , // vesting

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -81,4 +81,12 @@ contract Api3TokenMock is MiniMeToken {
         external
     {
     }
+
+    function isGenesisEpoch()
+        external
+        view
+        returns (bool)
+    {
+        return false;
+    }
 }

--- a/packages/api3-voting/test/delegation-integration.js
+++ b/packages/api3-voting/test/delegation-integration.js
@@ -46,6 +46,9 @@ contract(
 
       votingBase = await Voting.new();
       pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
+      // Wait for the Genesis epoch to pass
+      const latest = Number(await time.latest());
+      await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
 
       // ROLES are below
       CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE();

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -358,7 +358,7 @@ contract(
             calldata: executionTarget.contract.methods.execute().encodeABI(),
           };
           const script = encodeCallScript([action]);
-          await voting.newVote(script, "", { from: holder51 });
+          await voting.methods['newVote(bytes,string,bool,bool)'](script, "", true, true, { from: holder51 });
           assert.equal(
             await executionTarget.counter(),
             1,
@@ -557,6 +557,11 @@ contract(
           });
 
           it("holder can vote", async () => {
+            assert.equal(
+              await voting.canVote(voteId, holder29),
+              true,
+              "holder should be able to vote"
+            );
             await voting.vote(voteId, false, true, { from: holder29 });
             const state = await voting.getVote(voteId);
             const voterState = await voting.getVoterState(voteId, holder29);
@@ -608,6 +613,11 @@ contract(
           });
 
           it("throws when non-holder votes", async () => {
+            assert.equal(
+              await voting.canVote(voteId, nonHolder),
+              false,
+              "non-holder should not be able to vote"
+            );
             await assertRevert(
               voting.vote(voteId, true, true, { from: nonHolder }),
               ERRORS.VOTING_CAN_NOT_VOTE
@@ -616,6 +626,11 @@ contract(
 
           it("throws when voting after voting closes", async () => {
             await voting.mockIncreaseTime(votingDuration + 1);
+            assert.equal(
+              await voting.canVote(voteId, holder29),
+              false,
+              "holder should not be able to vote after voting closes"
+            );
             await assertRevert(
               voting.vote(voteId, true, true, { from: holder29 }),
               ERRORS.VOTING_CAN_NOT_VOTE

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -19,9 +19,9 @@ const {
   ANY_ENTITY,
   EMPTY_CALLS_SCRIPT,
 } = require("@aragon/contract-helpers-test/src/aragon-os");
+const { time } = require("@openzeppelin/test-helpers");
 
 const Voting = artifacts.require("Api3VotingMock");
-
 const Api3TokenMock = artifacts.require("Api3TokenMock");
 const Api3Pool = artifacts.require("Api3Pool");
 const ExecutionTarget = artifacts.require("ExecutionTarget");
@@ -83,6 +83,86 @@ contract(
       );
     });
 
+    context("still in Genesis epoch", () => {
+      const neededSupport = pct16(50);
+      const minimumAcceptanceQuorum = pct16(20);
+
+      beforeEach(async () => {
+        const decimals = 0;
+        token = await Api3TokenMock.new(
+          ZERO_ADDRESS,
+          ZERO_ADDRESS,
+          0,
+          "n",
+          decimals,
+          "n",
+          true
+        ); // empty parameters minime
+        api3Pool = await Api3Pool.new(
+          token.address,
+          MOCK_TIMELOCKMANAGER_ADDRESS
+        );
+        await api3Pool.setDaoApps(
+          voting.address,
+          voting.address,
+          voting.address,
+          voting.address
+        );
+
+        await token.generateTokens(holder20, bigExp(2000, decimals));
+        await token.generateTokens(holder29, bigExp(2900, decimals));
+        await token.generateTokens(holder51, bigExp(5100, decimals));
+        await token.generateTokens(holder1, bigExp(1, decimals));
+
+        await voting.initialize(
+          api3Pool.address,
+          neededSupport,
+          minimumAcceptanceQuorum
+        );
+
+        // holder 51 deposit and stake
+        await token.approve(api3Pool.address, bigExp(5100, decimals), {
+          from: holder51,
+        });
+        await api3Pool.depositAndStake(bigExp(5100, decimals), {
+          from: holder51,
+        });
+
+        // holder 29
+        await token.approve(api3Pool.address, bigExp(2900, decimals), {
+          from: holder29,
+        });
+        await api3Pool.depositAndStake(bigExp(2900, decimals), {
+          from: holder29,
+        });
+
+        // holder 20
+        await token.approve(api3Pool.address, bigExp(2000, decimals), {
+          from: holder20,
+        });
+        await api3Pool.depositAndStake(bigExp(2000, decimals), {
+          from: holder20,
+        });
+
+        // holder 1
+        await token.approve(api3Pool.address, bigExp(1, decimals), {
+          from: holder1,
+        });
+        await api3Pool.depositAndStake(bigExp(1, decimals), {
+          from: holder1,
+        });
+
+        executionTarget = await ExecutionTarget.new();
+      });
+
+      it("new votes revert", async () => {
+        await assertRevert(
+          voting.newVote(EMPTY_CALLS_SCRIPT, "", { from: holder51 }),
+          "API3_GENESIS_EPOCH"
+        );
+      });
+    });
+
     context("normal token supply, common tests", () => {
       const neededSupport = pct16(50);
       const minimumAcceptanceQuorum = pct16(20);
@@ -101,6 +181,9 @@ contract(
           token.address,
           MOCK_TIMELOCKMANAGER_ADDRESS
         );
+        // Wait for the Genesis epoch to pass
+        const latest = Number(await time.latest());
+        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
         await api3Pool.setDaoApps(
           voting.address,
           voting.address,
@@ -213,6 +296,9 @@ contract(
             token.address,
             MOCK_TIMELOCKMANAGER_ADDRESS
           );
+          // Wait for the Genesis epoch to pass
+          const latest = Number(await time.latest());
+          await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
           await api3Pool.setDaoApps(
             voting.address,
             voting.address,

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -431,6 +431,18 @@ contract StateUtils is IStateUtils {
             );
     }
 
+    /// @notice Called to check if we are in the genesis epoch
+    /// @dev Voting apps use this to prevent proposals from being made in the
+    /// genesis epoch
+    function isGenesisEpoch()
+        external
+        view
+        override
+        returns (bool)
+    {
+        return block.timestamp / EPOCH_LENGTH == genesisEpoch;
+    }
+
     /// @notice Called internally to update the total shares history
     /// @dev `fromBlock0` and `fromBlock1` will be two different block numbers
     /// when totalShares history was last updated. If one of these

--- a/packages/pool/contracts/interfaces/IStateUtils.sol
+++ b/packages/pool/contracts/interfaces/IStateUtils.sol
@@ -84,4 +84,9 @@ interface IStateUtils {
 
     function updateLastProposalTimestamp(address userAddress)
         external;
+
+    function isGenesisEpoch()
+        external
+        view
+        returns (bool);
 }

--- a/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
+++ b/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
@@ -42,4 +42,9 @@ interface IApi3Pool {
             uint256 lastDelegationUpdateTimestamp,
             uint256 lastProposalTimestamp
             );
+
+    function isGenesisEpoch()
+        external
+        view
+        returns (bool);
 }

--- a/packages/pool/test/StateUtils.sol.js
+++ b/packages/pool/test/StateUtils.sol.js
@@ -816,3 +816,20 @@ describe("updateLastProposalTimestamp", function () {
     });
   });
 });
+
+describe("isGenesisEpoch", function () {
+  context("Is genesis epoch", function () {
+    it("returns true", async function () {
+      expect(await api3Pool.isGenesisEpoch()).to.equal(true);
+    });
+  });
+  context("Is not genesis epoch", function () {
+    it("returns false", async function () {
+      await ethers.provider.send("evm_increaseTime", [
+        (await api3Pool.EPOCH_LENGTH()).toNumber() + 1,
+      ]);
+      await ethers.provider.send("evm_mine");
+      expect(await api3Pool.isGenesisEpoch()).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR prevents new proposals from being made in the genesis epoch. This is to prevent the first staker from immediately making a new proposal to break the DAO setup (by calling `setDaoApps()` at the pool or updating the DAO ACL). It is assumed that enough holders will stake in the first epoch, so this won't be a problem in the following epochs.

In addition, api3-voting test coverage is completed to 100%.