### PR TITLE
Make hardcoded constants specifiable

### DIFF
--- a/packages/api3-voting/README.md
+++ b/packages/api3-voting/README.md
@@ -4,7 +4,7 @@ This is a customized version of the [Aragon Voting app](https://github.com/arago
 It integrates to the API3 pool instead of a generic MiniMe token to determine voting power.
 It also implements the following additional features:
 
-- Does not allow users to create a new vote less than `EPOCH_LENGTH` (defined in the API3 pool) apart (immutably set as 1 week)
+- Does not allow users to create a new vote less than `epochLength` (defined in the API3 pool) apart (immutably set as 1 week)
 - Does not allow users that have less than `proposalVotingPowerThreshold` (defined in the API3 pool) to create a new vote (governable, initial value 0.1%)
 
 ## Instructions

--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -93,8 +93,8 @@ contract Api3Voting is IForwarder, AragonApp {
         minAcceptQuorumPct = _minAcceptQuorumPct;
         // The pool acts as the MiniMe token
         api3Pool = IApi3Pool(_token);
-        // Unlike the original Voting app, `voteTime` has to be `EPOCH_LENGTH` of the pool
-        voteTime = uint64(api3Pool.EPOCH_LENGTH());
+        // Unlike the original Voting app, `voteTime` has to be `epochLength` of the pool
+        voteTime = uint64(api3Pool.epochLength());
     }
 
     /**
@@ -265,7 +265,7 @@ contract Api3Voting is IForwarder, AragonApp {
             , // lastDelegationUpdateTimestamp
             uint256 lastProposalTimestamp
             ) = api3Pool.getUser(msg.sender);
-        require(lastProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
+        require(lastProposalTimestamp.add(api3Pool.epochLength()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         api3Pool.updateLastProposalTimestamp(msg.sender);
 
         uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block

--- a/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
+++ b/packages/api3-voting/contracts/test/mocks/Api3TokenMock.sol
@@ -26,7 +26,7 @@ contract Api3TokenMock is MiniMeToken {
     {
     }
 
-    uint256 public EPOCH_LENGTH = 7 * 24 * 60 * 60;
+    uint256 public epochLength = 7 * 24 * 60 * 60;
     uint256 private mockProposalVotingPowerThreshold = 0;
 
     function userVotingPowerAt(address userAddress, uint256 _block)

--- a/packages/api3-voting/test/delegation-integration.js
+++ b/packages/api3-voting/test/delegation-integration.js
@@ -22,6 +22,7 @@ const createdVoteId = (receipt) =>
 
 const MOCK_TIMELOCKMANAGER_ADDRESS =
   "0x0000000000000000000000000000000000000001";
+const epochLength = Number(time.duration.weeks(1));
 
 contract(
   "API3 Voting App delegation tests",
@@ -45,10 +46,10 @@ contract(
       );
 
       votingBase = await Voting.new();
-      pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS);
+      pool = await Api3Pool.new(token.address, MOCK_TIMELOCKMANAGER_ADDRESS, epochLength);
       // Wait for the Genesis epoch to pass
       const latest = Number(await time.latest());
-      await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+      await time.increaseTo(latest + epochLength + 1);
 
       // ROLES are below
       CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE();
@@ -159,7 +160,7 @@ contract(
 
       it("undo delegate", async () => {
         const latest = Number(await time.latest());
-        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+        await time.increaseTo(latest + epochLength + 1);
         await pool.undelegateVotingPower({ from: voter1 });
         const voteId = createdVoteId(
           await voting.newVote(EMPTY_CALLS_SCRIPT, "metadata", { from: voter3 })
@@ -171,7 +172,7 @@ contract(
 
       it("delegate delegated", async () => {
         let latest = Number(await time.latest());
-        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+        await time.increaseTo(latest + epochLength + 1);
         await pool.delegateVotingPower(voter2, { from: voter1 });
         await pool.delegateVotingPower(voter3, { from: voter2 });
         const voteId = createdVoteId(
@@ -183,14 +184,14 @@ contract(
 
       it("delegate delegated in a cycle", async () => {
         let latest = Number(await time.latest());
-        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+        await time.increaseTo(latest + epochLength + 1);
         await pool.undelegateVotingPower({ from: voter2 });
         await expectRevert(
           pool.delegateVotingPower(voter2, { from: voter1 }),
           "Pool: Already delegated"
         );
         latest = Number(await time.latest());
-        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+        await time.increaseTo(latest + epochLength + 1);
         await expectRevert(
           pool.delegateVotingPower(voter1, { from: voter2 }),
           "Pool: Delegate is delegating"

--- a/packages/api3-voting/test/voting.js
+++ b/packages/api3-voting/test/voting.js
@@ -35,6 +35,7 @@ const VOTER_STATE = ["ABSENT", "YEA", "NAY"].reduce((state, key, index) => {
 }, {});
 const MOCK_TIMELOCKMANAGER_ADDRESS =
   "0x0000000000000000000000000000000000000001";
+const epochLength = Number(time.duration.weeks(1));
 
 contract(
   "API3 Voting App",
@@ -100,7 +101,8 @@ contract(
         ); // empty parameters minime
         api3Pool = await Api3Pool.new(
           token.address,
-          MOCK_TIMELOCKMANAGER_ADDRESS
+          MOCK_TIMELOCKMANAGER_ADDRESS,
+          epochLength
         );
         await api3Pool.setDaoApps(
           voting.address,
@@ -179,11 +181,12 @@ contract(
         ); // empty parameters minime
         api3Pool = await Api3Pool.new(
           token.address,
-          MOCK_TIMELOCKMANAGER_ADDRESS
+          MOCK_TIMELOCKMANAGER_ADDRESS,
+          epochLength
         );
         // Wait for the Genesis epoch to pass
         const latest = Number(await time.latest());
-        await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+        await time.increaseTo(latest + epochLength + 1);
         await api3Pool.setDaoApps(
           voting.address,
           voting.address,
@@ -294,11 +297,12 @@ contract(
           ); // empty parameters minime
           api3Pool = await Api3Pool.new(
             token.address,
-            MOCK_TIMELOCKMANAGER_ADDRESS
+            MOCK_TIMELOCKMANAGER_ADDRESS,
+            epochLength
           );
           // Wait for the Genesis epoch to pass
           const latest = Number(await time.latest());
-          await time.increaseTo(latest + Number(time.duration.weeks(1)) + 1);
+          await time.increaseTo(latest + epochLength + 1);
           await api3Pool.setDaoApps(
             voting.address,
             voting.address,

--- a/packages/convenience/test/Convenience.sol.js
+++ b/packages/convenience/test/Convenience.sol.js
@@ -8,6 +8,7 @@ let mockApi3VotingPrimary,
   api3Pool,
   convenience;
 let roles, erc20Tokens;
+const epochLength = 7 * 24 * 60 * 60;
 
 const VotingAppType = Object.freeze({ Primary: 0, Secondary: 1 });
 const VoterStateType = Object.freeze({ ABSENT: 0, YEA: 1, NAY: 2 });
@@ -46,7 +47,8 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     mockApi3Token.address,
-    roles.mockTimeLockManager.address
+    roles.mockTimeLockManager.address,
+    epochLength
   );
 
   await api3Pool.setDaoApps(

--- a/packages/dao/README.md
+++ b/packages/dao/README.md
@@ -18,7 +18,7 @@ npm run test
 
 Run this
 ```sh
-npx ganache-cli -i 15 --gasLimit 8000000 --port 8545
+npx ganache-cli --gasLimit 8000000
 ```
 
 and this on a separate terminal
@@ -107,7 +107,7 @@ aragon dao acl <DAO kernel address> --use-frame
 
 7. Check that the following values are initialized correctly
 - `api3Pool` and the voting parameters (`supportRequiredPct` and `minAcceptQuorumPct`) at the Api3Voting apps
-- `api3Token`, `timelockManager`, `agentAppPrimary`, `agentAppSecondary`, `votingAppPrimary` and `votingAppSecondary` at the pool contract
+- `api3Token`, `timelockManager`, `agentAppPrimary`, `agentAppSecondary`, `votingAppPrimary`, `votingAppSecondary` and `epochLength` (7 * 24 * 60 * 60) at the pool contract
 - If any claims manager contracts are set for the pool, they are audited and implemented to pay out claims in a trustless way with fail-safes such as payout limits (note that the pool will be deployed with no claims managers set initially)
 
 ## Permissions

--- a/packages/dao/contracts/Api3Template.sol
+++ b/packages/dao/contracts/Api3Template.sol
@@ -11,7 +11,7 @@ contract Api3Template is BaseTemplate {
 
     // The Api3Voting app ID below is used on localhost
     // It is derived using `namehash("api3voting.aragonpm.eth")`
-    bytes32 constant internal API3_VOTING_APP_ID = 0x727a0cf100ef0e645bad5a5b920d7fb71f8fd0eaf0fa579c341a045f597526f5;
+    // bytes32 constant internal API3_VOTING_APP_ID = 0x727a0cf100ef0e645bad5a5b920d7fb71f8fd0eaf0fa579c341a045f597526f5;
 
     string constant private ERROR_BAD_VOTE_SETTINGS = "API3_DAO_BAD_VOTE_SETTINGS";
 
@@ -51,7 +51,8 @@ contract Api3Template is BaseTemplate {
         string _id,
         MiniMeToken _api3Pool,
         uint64[2] _primaryVotingSettings,
-        uint64[2] _secondaryVotingSettings
+        uint64[2] _secondaryVotingSettings,
+        bytes32 api3VotingAppId
     )
     external
     {
@@ -63,7 +64,7 @@ contract Api3Template is BaseTemplate {
 
         (Kernel dao, ACL acl) = _createDAO();
         (Api3Voting primaryVoting, Api3Voting secondaryVoting, Agent primaryAgent, Agent secondaryAgent) = _setupApps(
-            dao, acl, _api3Pool, _primaryVotingSettings,_secondaryVotingSettings
+            dao, acl, _api3Pool, _primaryVotingSettings, _secondaryVotingSettings, api3VotingAppId
         );
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, primaryVoting);
         _registerID(_id, dao);
@@ -84,15 +85,16 @@ contract Api3Template is BaseTemplate {
         ACL _acl,
         MiniMeToken _api3Pool,
         uint64[2] memory _primaryVotingSettings,
-        uint64[2] memory _secondaryVotingSettings
+        uint64[2] memory _secondaryVotingSettings,
+        bytes32 api3VotingAppId
     )
     internal
     returns (Api3Voting, Api3Voting, Agent, Agent)
     {
         Agent primaryAgent = _installDefaultAgentApp(_dao);
         Agent secondaryAgent = _installNonDefaultAgentApp(_dao);
-        Api3Voting primaryVoting = _installApi3VotingApp(_dao, _api3Pool, _primaryVotingSettings);
-        Api3Voting secondaryVoting = _installApi3VotingApp(_dao, _api3Pool, _secondaryVotingSettings);
+        Api3Voting primaryVoting = _installApi3VotingApp(_dao, _api3Pool, _primaryVotingSettings, api3VotingAppId);
+        Api3Voting secondaryVoting = _installApi3VotingApp(_dao, _api3Pool, _secondaryVotingSettings, api3VotingAppId);
 
         _setupPermissions(
             _acl,
@@ -131,20 +133,21 @@ contract Api3Template is BaseTemplate {
 
     /*API3 VOTING*/
 
-    function _installApi3VotingApp(Kernel _dao, MiniMeToken _token, uint64[2] memory _votingSettings) internal returns (Api3Voting) {
-        return _installApi3VotingApp(_dao, _token, _votingSettings[0], _votingSettings[1]);
+    function _installApi3VotingApp(Kernel _dao, MiniMeToken _token, uint64[2] memory _votingSettings, bytes32 api3VotingAppId) internal returns (Api3Voting) {
+        return _installApi3VotingApp(_dao, _token, _votingSettings[0], _votingSettings[1], api3VotingAppId);
     }
 
     function _installApi3VotingApp(
         Kernel _dao,
         MiniMeToken _token,
         uint64 _support,
-        uint64 _acceptance
+        uint64 _acceptance,
+        bytes32 api3VotingAppId
     )
     internal returns (Api3Voting)
     {
         bytes memory initializeData = abi.encodeWithSelector(Api3Voting(0).initialize.selector, _token, _support, _acceptance);
-        return Api3Voting(_installNonDefaultApp(_dao, API3_VOTING_APP_ID, initializeData));
+        return Api3Voting(_installNonDefaultApp(_dao, api3VotingAppId, initializeData));
     }
 
     function _createApi3VotingPermissions(

--- a/packages/dao/scripts/deploy.js
+++ b/packages/dao/scripts/deploy.js
@@ -1,5 +1,5 @@
 /*global artifacts, web3, Promise*/
-
+const { hash: namehash } = require("eth-ens-namehash");
 const { getNetworkName } = require("@aragon/templates-shared/lib/network")(
   web3
 );
@@ -78,11 +78,15 @@ module.exports = async (callback) => {
         { name: "token-manager", contractName: "TokenManager" },
       ]
     );
+    const api3VotingAppId = network === "rinkeby" || network === "mainnet" || network === "ropsten"
+        ? namehash("api3voting.open.aragonpm.eth")
+        : namehash("api3voting.aragonpm.eth");
     const tx = await template.newInstance(
       DAO_ID,
       api3Pool.address,
       [SUPPORT_1, ACCEPTANCE_1],
-      [SUPPORT_2, ACCEPTANCE_2]
+      [SUPPORT_2, ACCEPTANCE_2],
+      api3VotingAppId
     );
     const primaryVoting = getEventArgument(
       tx,

--- a/packages/dao/scripts/deploy.js
+++ b/packages/dao/scripts/deploy.js
@@ -21,6 +21,8 @@ const ACCEPTANCE_1 = 50e16;
 const SUPPORT_2 = 50e16;
 const ACCEPTANCE_2 = 15e16;
 
+const EPOCH_LENGTH = 7 * 24 * 60 * 60;
+
 /**
  * Returns the address of the deployer
  */
@@ -57,7 +59,7 @@ module.exports = async (callback) => {
 
     const api3Token = await Api3Token.new(deployer, deployer);
     // Set TimelockManager as deployer
-    const api3Pool = await Api3Pool.new(api3Token.address, deployer);
+    const api3Pool = await Api3Pool.new(api3Token.address, deployer, EPOCH_LENGTH);
     const convenience = await Convenience.new(api3Pool.address);
     const template = await deployTemplate(
       web3,

--- a/packages/dao/test/api3template.js
+++ b/packages/dao/test/api3template.js
@@ -26,13 +26,15 @@ contract("Api3Template", ([, deployer, tokenAddress, authorized]) => {
   const SUPPORT_2 = 50e16;
   const ACCEPTANCE_2 = 15e16;
 
+  const epochLength = 7 * 24 * 60 * 60;
+
   before("fetch bare template", async () => {
     api3Template = Api3Template.at(await getTemplateAddress());
   });
 
   before("create bare entity", async () => {
     // Set TimelockManager as deployer
-    api3Pool = await Api3Pool.new(tokenAddress, deployer, { from: deployer });
+    api3Pool = await Api3Pool.new(tokenAddress, deployer, epochLength, { from: deployer });
     receipt1 = await api3Template.newInstance(
       "api3template_test",
       api3Pool.address,

--- a/packages/dao/test/api3template.js
+++ b/packages/dao/test/api3template.js
@@ -40,6 +40,7 @@ contract("Api3Template", ([, deployer, tokenAddress, authorized]) => {
       api3Pool.address,
       [SUPPORT_1, ACCEPTANCE_1],
       [SUPPORT_2, ACCEPTANCE_2],
+      namehash("api3voting.aragonpm.eth"),
       { from: deployer }
     );
 

--- a/packages/pool/contracts/Api3Pool.sol
+++ b/packages/pool/contracts/Api3Pool.sol
@@ -23,13 +23,17 @@ import "./interfaces/IApi3Pool.sol";
 /// (9) StateUtils.sol
 contract Api3Pool is TimelockUtils, IApi3Pool {
     /// @param api3TokenAddress API3 token contract address
+    /// @param timelockManagerAddress Timelock manager contract address
+    /// @param _epochLength Epoch length in seconds
     constructor(
         address api3TokenAddress,
-        address timelockManagerAddress
+        address timelockManagerAddress,
+        uint256 _epochLength
         )
         StateUtils(
             api3TokenAddress,
-            timelockManagerAddress
+            timelockManagerAddress,
+            _epochLength
             )
     {}
 }

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -28,7 +28,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         // Do not allow frequent delegation updates as that can be used to spam
         // proposals
         require(
-            user.lastDelegationUpdateTimestamp + EPOCH_LENGTH < block.timestamp,
+            user.lastDelegationUpdateTimestamp + epochLength < block.timestamp,
             "Pool: Updated delegate recently"
             );
         user.lastDelegationUpdateTimestamp = block.timestamp;
@@ -85,7 +85,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             "Pool: Not delegated"
             );
         require(
-            user.lastDelegationUpdateTimestamp + EPOCH_LENGTH < block.timestamp,
+            user.lastDelegationUpdateTimestamp + epochLength < block.timestamp,
             "Pool: Updated delegate recently"
             );
 

--- a/packages/pool/contracts/GetterUtils.sol
+++ b/packages/pool/contracts/GetterUtils.sol
@@ -171,7 +171,7 @@ abstract contract GetterUtils is StateUtils, IGetterUtils {
         returns (uint256 locked)
     {
         Checkpoint[] storage _userShares = users[userAddress].shares;
-        uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
+        uint256 currentEpoch = block.timestamp / epochLength;
         uint256 oldestLockedEpoch = currentEpoch - REWARD_VESTING_PERIOD > genesisEpoch
             ? currentEpoch - REWARD_VESTING_PERIOD + 1
             : genesisEpoch + 1;

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -14,14 +14,14 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
         public
         override
     {
-        uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
+        uint256 currentEpoch = block.timestamp / epochLength;
         // This will be skipped in most cases because someone else will have
         // triggered the payment for this epoch
         if (epochIndexOfLastRewardPayment < currentEpoch)
         {
             if (api3Token.getMinterStatus(address(this)))
             {
-                uint256 rewardAmount = totalStake * currentApr * EPOCH_LENGTH / ONE_YEAR_IN_SECONDS / HUNDRED_PERCENT;
+                uint256 rewardAmount = totalStake * currentApr * epochLength / ONE_YEAR_IN_SECONDS / HUNDRED_PERCENT;
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: block.number,
                     amount: rewardAmount,

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -71,7 +71,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
             userSharesLength != 0,
             "Pool: User never had shares"
             );
-        uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
+        uint256 currentEpoch = block.timestamp / epochLength;
         LockedCalculationState storage state = userToLockedCalculationState[userAddress];
         // Reset the state if there was no calculation made in this epoch
         if (state.initialIndEpoch != currentEpoch)
@@ -121,7 +121,7 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         override
     {
         mintReward();
-        uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
+        uint256 currentEpoch = block.timestamp / epochLength;
         LockedCalculationState storage state = userToLockedCalculationState[msg.sender];
         require(
             state.initialIndEpoch == currentEpoch,

--- a/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
+++ b/packages/pool/contracts/interfaces/v0.4.24/IApi3Pool.sol
@@ -4,7 +4,7 @@ pragma solidity 0.4.24;
 /// @title A limited API3 pool contract interface to be used by Api3Voting.sol
 /// in the (at)api3-dao/api3-voting package
 interface IApi3Pool {
-    function EPOCH_LENGTH()
+    function epochLength()
         external
         view
         returns(uint256);

--- a/packages/pool/test/ClaimUtils.sol.js
+++ b/packages/pool/test/ClaimUtils.sol.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
+const epochLength = 7 * 24 * 60 * 60;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -31,7 +32,8 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
 });
 

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool, api3Voting;
-let EPOCH_LENGTH;
+const epochLength = 7 * 24 * 60 * 60;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -32,7 +32,8 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
   const api3VotingFactory = await ethers.getContractFactory(
     "MockApi3Voting",
@@ -47,7 +48,6 @@ beforeEach(async () => {
       api3Voting.address,
       roles.votingAppSecondary.address
     );
-  EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
 });
 
 describe("delegateVotingPower", function () {
@@ -97,7 +97,7 @@ describe("delegateVotingPower", function () {
                   ).to.equal(user1Stake);
                   // Fast forward time
                   await ethers.provider.send("evm_increaseTime", [
-                    EPOCH_LENGTH.toNumber() + 1,
+                    epochLength + 1,
                   ]);
                   // ... then have user 1 delegate to user 2
                   await expect(
@@ -164,7 +164,7 @@ describe("delegateVotingPower", function () {
                   .delegateVotingPower(roles.user2.address);
                 // Fast forward time
                 await ethers.provider.send("evm_increaseTime", [
-                  EPOCH_LENGTH.toNumber() + 1,
+                  epochLength + 1,
                 ]);
                 // ... then have user 1 delegate to user 2 again
                 await expect(
@@ -289,7 +289,7 @@ describe("undelegateVotingPower", function () {
             .delegateVotingPower(roles.user2.address);
           // Fast forward time
           await ethers.provider.send("evm_increaseTime", [
-            EPOCH_LENGTH.toNumber() + 1,
+            epochLength + 1,
           ]);
           // Have user 1 undelegate
           await expect(api3Pool.connect(roles.user1).undelegateVotingPower())

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
-let EPOCH_LENGTH;
+const epochLength = 7 * 24 * 60 * 60;
 const HUNDRED_PERCENT = ethers.BigNumber.from(`1${"0".repeat(18)}`);
 const ONE_YEAR_IN_SECONDS = ethers.BigNumber.from(52 * 7 * 24 * 60 * 60);
 
@@ -34,9 +34,9 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
-  EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
 });
 
 describe("mintReward", function () {
@@ -73,7 +73,7 @@ describe("mintReward", function () {
             for (let ind = 0; ind < 50; ind++) {
               nextEpoch = nextEpoch.add(ethers.BigNumber.from(1));
               await ethers.provider.send("evm_setNextBlockTimestamp", [
-                nextEpoch.mul(EPOCH_LENGTH).toNumber(),
+                nextEpoch.mul(epochLength).toNumber(),
               ]);
               // Pay reward
               const totalStake = await api3Pool.totalStake();
@@ -85,7 +85,7 @@ describe("mintReward", function () {
               }
               const rewardAmount = totalStake
                 .mul(currentApr)
-                .mul(EPOCH_LENGTH)
+                .mul(epochLength)
                 .div(ONE_YEAR_IN_SECONDS)
                 .div(HUNDRED_PERCENT);
               await expect(api3Pool.connect(roles.randomPerson).mintReward())
@@ -136,7 +136,7 @@ describe("mintReward", function () {
             for (let ind = 0; ind < 50; ind++) {
               nextEpoch = nextEpoch.add(ethers.BigNumber.from(1));
               await ethers.provider.send("evm_setNextBlockTimestamp", [
-                nextEpoch.mul(EPOCH_LENGTH).toNumber(),
+                nextEpoch.mul(epochLength).toNumber(),
               ]);
               // Pay reward
               const totalStake = await api3Pool.totalStake();
@@ -148,7 +148,7 @@ describe("mintReward", function () {
               }
               const rewardAmount = totalStake
                 .mul(currentApr)
-                .mul(EPOCH_LENGTH)
+                .mul(epochLength)
                 .div(ONE_YEAR_IN_SECONDS)
                 .div(HUNDRED_PERCENT);
               await expect(api3Pool.connect(roles.randomPerson).mintReward())
@@ -194,7 +194,7 @@ describe("mintReward", function () {
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
+          genesisEpochPlusOne.mul(epochLength).toNumber(),
         ]);
         // Pay reward
         const totalStake = await api3Pool.totalStake();
@@ -239,7 +239,7 @@ describe("mintReward", function () {
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
+          genesisEpochPlusFive.mul(epochLength).toNumber(),
         ]);
         // Pay reward
         const totalStake = await api3Pool.totalStake();
@@ -248,7 +248,7 @@ describe("mintReward", function () {
         const newApr = currentApr.sub(aprUpdateStep);
         const rewardAmount = totalStake
           .mul(currentApr)
-          .mul(EPOCH_LENGTH)
+          .mul(epochLength)
           .div(ONE_YEAR_IN_SECONDS)
           .div(HUNDRED_PERCENT);
         await expect(api3Pool.connect(roles.randomPerson).mintReward())
@@ -289,7 +289,7 @@ describe("mintReward", function () {
         const genesisEpoch = await api3Pool.genesisEpoch();
         const genesisEpochPlusFive = genesisEpoch.add(ethers.BigNumber.from(5));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          genesisEpochPlusFive.mul(EPOCH_LENGTH).toNumber(),
+          genesisEpochPlusFive.mul(epochLength).toNumber(),
         ]);
         // Pay reward
         const totalStake = await api3Pool.totalStake();
@@ -333,7 +333,7 @@ describe("mintReward", function () {
       const genesisEpoch = await api3Pool.genesisEpoch();
       const genesisEpochPlusOne = genesisEpoch.add(ethers.BigNumber.from(1));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
-        genesisEpochPlusOne.mul(EPOCH_LENGTH).toNumber(),
+        genesisEpochPlusOne.mul(epochLength).toNumber(),
       ]);
       // Pay reward
       await api3Pool.connect(roles.randomPerson).mintReward();

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
-let EPOCH_LENGTH;
+const epochLength = 7 * 24 * 60 * 60;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -32,9 +32,9 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
-  EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
 });
 
 describe("stake", function () {
@@ -158,7 +158,7 @@ describe("scheduleUnstake", function () {
         const unstakeScheduledFor = ethers.BigNumber.from(
           currentBlock.timestamp
         )
-          .add(EPOCH_LENGTH)
+          .add(epochLength)
           .add(ethers.BigNumber.from(1));
         // Schedule unstake
         const user1Shares = await api3Pool.userShares(roles.user1.address);
@@ -242,7 +242,7 @@ describe("unstake", function () {
               ethers.BigNumber.from(2)
             );
             await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
+              genesisEpochPlusTwo.mul(epochLength).toNumber(),
             ]);
             // Unstake
             await api3Pool.mintReward();
@@ -287,7 +287,7 @@ describe("unstake", function () {
               ethers.BigNumber.from(2)
             );
             await ethers.provider.send("evm_setNextBlockTimestamp", [
-              genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
+              genesisEpochPlusTwo.mul(epochLength).toNumber(),
             ]);
             // Unstake
             await api3Pool.mintReward();
@@ -347,7 +347,7 @@ describe("unstake", function () {
             ethers.BigNumber.from(2)
           );
           await ethers.provider.send("evm_setNextBlockTimestamp", [
-            genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
+            genesisEpochPlusTwo.mul(epochLength).toNumber(),
           ]);
           // Unstake
           await api3Pool.mintReward();
@@ -417,7 +417,7 @@ describe("unstakeAndWithdraw", function () {
     const genesisEpoch = await api3Pool.genesisEpoch();
     const genesisEpochPlusTwo = genesisEpoch.add(ethers.BigNumber.from(2));
     await ethers.provider.send("evm_setNextBlockTimestamp", [
-      genesisEpochPlusTwo.mul(EPOCH_LENGTH).toNumber(),
+      genesisEpochPlusTwo.mul(epochLength).toNumber(),
     ]);
     // Unstake and withdraw
     await api3Pool.connect(roles.user1).unstakeAndWithdraw();

--- a/packages/pool/test/TimelockUtils.sol.js
+++ b/packages/pool/test/TimelockUtils.sol.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
+const epochLength = 7 * 24 * 60 * 60;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -32,7 +33,8 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
 });
 

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -2,7 +2,8 @@ const { expect } = require("chai");
 
 let roles;
 let api3Token, api3Pool;
-let EPOCH_LENGTH, REWARD_VESTING_PERIOD;
+const epochLength = 7 * 24 * 60 * 60;
+let REWARD_VESTING_PERIOD;
 
 beforeEach(async () => {
   const accounts = await ethers.getSigners();
@@ -32,9 +33,9 @@ beforeEach(async () => {
   );
   api3Pool = await api3PoolFactory.deploy(
     api3Token.address,
-    roles.mockTimelockManager.address
+    roles.mockTimelockManager.address,
+    epochLength
   );
-  EPOCH_LENGTH = await api3Pool.EPOCH_LENGTH();
   REWARD_VESTING_PERIOD = await api3Pool.REWARD_VESTING_PERIOD();
 });
 
@@ -76,7 +77,7 @@ describe("withdrawRegular", function () {
       for (let i = 0; i < 100; i++) {
         const currentEpoch = genesisEpoch.add(ethers.BigNumber.from(i + 1));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          currentEpoch.mul(EPOCH_LENGTH).toNumber(),
+          currentEpoch.mul(epochLength).toNumber(),
         ]);
         await api3Pool.mintReward();
       }
@@ -85,7 +86,7 @@ describe("withdrawRegular", function () {
         .connect(roles.user1)
         .scheduleUnstake(await api3Pool.userShares(roles.user1.address));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
-        genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
+        genesisEpoch.add(102).mul(epochLength).toNumber(),
       ]);
       await api3Pool.connect(roles.randomPerson).unstake(roles.user1.address);
       const userBefore = await api3Pool.users(roles.user1.address);
@@ -149,7 +150,7 @@ describe("precalculateUserLocked", function () {
           for (let i = 0; i < noEpochsToFastForward; i++) {
             const currentEpoch = genesisEpoch.add(ethers.BigNumber.from(i + 1));
             await ethers.provider.send("evm_setNextBlockTimestamp", [
-              currentEpoch.mul(EPOCH_LENGTH).toNumber(),
+              currentEpoch.mul(epochLength).toNumber(),
             ]);
             await api3Pool.mintReward();
           }
@@ -243,7 +244,7 @@ describe("withdrawPrecalculated", function () {
       for (let i = 0; i < noEpochsToFastForward; i++) {
         const currentEpoch = genesisEpoch.add(ethers.BigNumber.from(i + 1));
         await ethers.provider.send("evm_setNextBlockTimestamp", [
-          currentEpoch.mul(EPOCH_LENGTH).toNumber(),
+          currentEpoch.mul(epochLength).toNumber(),
         ]);
         await api3Pool.mintReward();
       }
@@ -252,7 +253,7 @@ describe("withdrawPrecalculated", function () {
         .connect(roles.user1)
         .scheduleUnstake(await api3Pool.userShares(roles.user1.address));
       await ethers.provider.send("evm_setNextBlockTimestamp", [
-        genesisEpoch.add(102).mul(EPOCH_LENGTH).toNumber(),
+        genesisEpoch.add(102).mul(epochLength).toNumber(),
       ]);
       await api3Pool.connect(roles.randomPerson).unstake(roles.user1.address);
       await api3Pool


### PR DESCRIPTION
`EPOCH_LENGTH` was hardcoded in the pool contracts, making it difficult to use different settings for testing convenience.
`API3_VOTING_APP_ID` was hardcoded in the DAO contracts, and required lines to be manually commented/uncommented depending on which chain the DAO was going to be deployed on.
Made both of these constants specifiable during deployment.