### PR TITLE
[QSP-3-fix] Check if the user locked precalculation is complete

### DIFF
--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -126,7 +126,17 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         payReward();
         uint256 currentEpoch = block.timestamp / EPOCH_LENGTH;
         LockedCalculationState storage state = userToLockedCalculationState[msg.sender];
-        require(state.initialIndEpoch == currentEpoch, "Locked amount not precalculated");
+        require(
+            state.initialIndEpoch == currentEpoch,
+            "Calculation not up to date"
+            );
+        uint256 oldestLockedEpoch = currentEpoch - REWARD_VESTING_PERIOD > genesisEpoch
+            ? currentEpoch - REWARD_VESTING_PERIOD + 1
+            : genesisEpoch + 1;
+        require(
+            state.nextIndEpoch < oldestLockedEpoch,
+            "Calculation not complete"
+            );
         withdraw(destination, amount, state.locked);
     }
 


### PR DESCRIPTION
In the previous implementation, whether the precalculation of locked tokens has completed wasn't being checked, i.e., the user could start the precalculation and call `withdrawPrecalculated()` before it is completed, effectively allowing them to withdraw tokens that shouldn't be withdrawable yet. An additional `require()` statement is added to verify that the precalculation is complete, and unit tests are extended to validate the implementation.