### PR TITLE
Have treasury always report ETH balances

### DIFF
--- a/packages/api3-voting/package-lock.json
+++ b/packages/api3-voting/package-lock.json
@@ -7263,6 +7263,32 @@
 				"ethereumjs-util": "^5.1.1"
 			},
 			"dependencies": {
+				"ethereumjs-abi": {
+					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+					"dev": true,
+					"requires": {
+						"bn.js": "^4.11.8",
+						"ethereumjs-util": "^6.0.0"
+					},
+					"dependencies": {
+						"ethereumjs-util": {
+							"version": "6.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+							"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+							"dev": true,
+							"requires": {
+								"@types/bn.js": "^4.11.3",
+								"bn.js": "^4.11.0",
+								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
+								"ethjs-util": "0.1.6",
+								"rlp": "^2.2.3"
+							}
+						}
+					}
+				},
 				"ethereumjs-util": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
@@ -25012,7 +25038,7 @@
 					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 					"dev": true,
 					"requires": {
-						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
 						"crypto-js": "^3.1.4",
 						"utf8": "^2.1.1",
 						"xhr2": "*",

--- a/packages/convenience/contracts/Convenience.sol
+++ b/packages/convenience/contracts/Convenience.sol
@@ -131,11 +131,11 @@ contract Convenience is Ownable  {
             uint256 lastProposalTimestamp
             )
     {
-        names = new string[](erc20Addresses.length);
-        symbols = new string[](erc20Addresses.length);
-        decimals = new uint8[](erc20Addresses.length);
-        balancesOfPrimaryAgent = new uint256[](erc20Addresses.length);
-        balancesOfSecondaryAgent = new uint256[](erc20Addresses.length);
+        names = new string[](erc20Addresses.length + 1);
+        symbols = new string[](erc20Addresses.length + 1);
+        decimals = new uint8[](erc20Addresses.length + 1);
+        balancesOfPrimaryAgent = new uint256[](erc20Addresses.length + 1);
+        balancesOfSecondaryAgent = new uint256[](erc20Addresses.length + 1);
         for (uint256 i = 0; i < erc20Addresses.length; i++)
         {
             IERC20Metadata erc20 = IERC20Metadata(erc20Addresses[i]);
@@ -145,6 +145,11 @@ contract Convenience is Ownable  {
             balancesOfPrimaryAgent[i] = erc20.balanceOf(api3Pool.agentAppPrimary());
             balancesOfSecondaryAgent[i] = erc20.balanceOf(api3Pool.agentAppSecondary());
         }
+        names[erc20Addresses.length] = "Ethereum";
+        symbols[erc20Addresses.length] = "ETH";
+        decimals[erc20Addresses.length] = 18;
+        balancesOfPrimaryAgent[erc20Addresses.length] = address(api3Pool.agentAppPrimary()).balance;
+        balancesOfSecondaryAgent[erc20Addresses.length] = address(api3Pool.agentAppSecondary()).balance;
         proposalVotingPowerThreshold = api3Pool.proposalVotingPowerThreshold();
         userVotingPower = api3Pool.userVotingPower(userAddress);
         delegate = api3Pool.userDelegate(userAddress);   

--- a/packages/dao/package-lock.json
+++ b/packages/dao/package-lock.json
@@ -3380,6 +3380,32 @@
 				"ethereumjs-util": "^5.1.1"
 			},
 			"dependencies": {
+				"ethereumjs-abi": {
+					"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+					"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+					"dev": true,
+					"requires": {
+						"bn.js": "^4.11.8",
+						"ethereumjs-util": "^6.0.0"
+					},
+					"dependencies": {
+						"ethereumjs-util": {
+							"version": "6.2.1",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+							"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+							"dev": true,
+							"requires": {
+								"@types/bn.js": "^4.11.3",
+								"bn.js": "^4.11.0",
+								"create-hash": "^1.1.2",
+								"elliptic": "^6.5.2",
+								"ethereum-cryptography": "^0.1.3",
+								"ethjs-util": "0.1.6",
+								"rlp": "^2.2.3"
+							}
+						}
+					}
+				},
 				"ethereumjs-util": {
 					"version": "5.2.1",
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",


### PR DESCRIPTION
Previously the treasury didn't report the ETH balances and there was no get that through Convenience.sol because it's not an ERC20. Now it always returns the ETH balances even if there are no ERC20 addresses set.
This may get a bit annoying to port to other chains.