### PR TITLE
Small fixes

### DIFF
--- a/packages/api3-voting/contracts/Api3Voting.sol
+++ b/packages/api3-voting/contracts/Api3Voting.sol
@@ -264,7 +264,7 @@ contract Api3Voting is IForwarder, AragonApp {
             , // lastDelegationUpdateTimestamp
             uint256 lastProposalTimestamp
             ) = api3Pool.getUser(msg.sender);
-        require(lastProposalTimestamp.add(api3Pool.EPOCH_LENGTH()) < now, "API3_HIT_PROPOSAL_COOLDOWN");
+        require(lastProposalTimestamp.add(voteTime) < now, "API3_HIT_PROPOSAL_COOLDOWN");
         api3Pool.updateLastProposalTimestamp(msg.sender);
 
         uint64 snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block

--- a/packages/convenience/contracts/Convenience.sol
+++ b/packages/convenience/contracts/Convenience.sol
@@ -16,7 +16,7 @@ contract Convenience is Ownable  {
     /// @notice Staking pool of the DAO
     IApi3PoolExtended public immutable api3Pool;
     /// @notice List of ERC20 addresses that will be displayed in the DAO
-    /// treasury
+    /// treasury. The ETH balance will also be displayed by default.
     /// @dev These are set by the owner of this contract
     address[] public erc20Addresses;
     /// @notice Links to the discussion venues for each vote
@@ -74,6 +74,26 @@ contract Convenience is Ownable  {
 
     /// @notice Used by the DAO dashboard client to retrieve user staking data
     /// @param userAddress User address
+    /// @return apr Staking reward APR
+    /// @return api3Supply API3 total supply
+    /// @return totalStake Total amount staked at the pool
+    /// @return totalShares Total pool shares (also represents total voting
+    /// power)
+    /// @return stakeTarget Pool stake target in percentages
+    /// @return userApi3Balance User API3 balance
+    /// @return userStaked Amount of staked tokens the user has at the pool
+    /// @return userUnstaked Amount of non-staked tokens the user has at the
+    /// pool
+    /// @return userVesting Amount of tokens not yet vested to the user (it is
+    /// not withdrawable, similar to `userLocked`)
+    /// @return userUnstakeAmount Amount of tokens the user scheduled to
+    /// unstake
+    /// @return userUnstakeShares Amount of shares the user gave up to schedule
+    /// the unstaking
+    /// @return userUnstakeScheduledFor Time when the scheduled unstake will
+    /// mature
+    /// @return userLocked Amount of rewards the user has received that are not
+    /// withdrawable yet
     function getUserStakingData(address userAddress)
         external
         view
@@ -114,7 +134,24 @@ contract Convenience is Ownable  {
 
     /// @notice Used by the DAO dashboard client to retrieve the treasury and
     /// user delegation data
+    /// @dev In addition to the ERC20 tokens, it returns the ETH balances of
+    /// the treasuries
     /// @param userAddress User address
+    /// @return names ERC20 (+ Ethereum) names
+    /// @return symbols ERC20 (+ Ethereum) symbols
+    /// @return decimals ERC20 (+ Ethereum) decimals
+    /// @return balancesOfPrimaryAgent ERC20 (+ Ethereum) balances of the
+    /// primary agent
+    /// @return balancesOfSecondaryAgent ERC20 (+ Ethereum) balances of the
+    /// secondary agent
+    /// @return proposalVotingPowerThreshold Proposal voting power threshold in
+    /// percentages
+    /// @return userVotingPower Voting power of the user, including delegations
+    /// @return delegatedToUser Voting power delegated to user
+    /// @return delegate Address that the user has delegated to
+    /// @return lastDelegationUpdateTimestamp When the user has last updated
+    /// their delegation
+    /// @return lastProposalTimestamp When the user has last made a proposal
     function getTreasuryAndUserDelegationData(address userAddress)
         external
         view
@@ -171,6 +208,17 @@ contract Convenience is Ownable  {
     /// @param votingAppType Enumerated voting app type (primary or secondary)
     /// @param userAddress User address
     /// @param voteIds Array of vote IDs for which data will be retrieved
+    /// @return startDate Start date of the vote
+    /// @return supportRequired Support required for the vote to pass in
+    /// percentages
+    /// @return minAcceptQuorum Minimum acceptance quorum required for the vote
+    /// to pass in percentages
+    /// @return votingPower Total voting power at the time the vote was created
+    /// @return script The EVMScript that will be run if the vote passes
+    /// @return userVotingPowerAt User's voting power at the time the vote was
+    /// created
+    /// @return discussionUrl Discussion URL set for the vote by the contract
+    /// owner
     function getStaticVoteData(
         VotingAppType votingAppType,
         address userAddress,
@@ -230,6 +278,13 @@ contract Convenience is Ownable  {
     /// @param votingAppType Enumerated voting app type (primary or secondary)
     /// @param userAddress User address
     /// @param voteIds Array of vote IDs for which data will be retrieved
+    /// @return executed If the vote has been executed
+    /// @return yea Total voting power voted for "For"
+    /// @return nay Total voting power voted for "Against"
+    /// @return voterState Vote cast by the user
+    /// @return delegateAt Address the user has delegated to at the time the
+    /// vote was created
+    /// @return delegateState Vote cast by the delegate of the user
     function getDynamicVoteData(
         VotingAppType votingAppType,
         address userAddress,

--- a/packages/convenience/contracts/Convenience.sol
+++ b/packages/convenience/contracts/Convenience.sol
@@ -268,7 +268,7 @@ contract Convenience is Ownable  {
                 , // open
                 executed[i],
                 , // startDate
-                snapshotBlock ,
+                snapshotBlock,
                 , // supportRequired
                 , // minAcceptQuorum
                 yea[i],

--- a/packages/convenience/test/Convenience.sol.js
+++ b/packages/convenience/test/Convenience.sol.js
@@ -356,25 +356,25 @@ describe("getTreasuryAndUserDelegationData", function () {
             await erc20Tokens[i].balanceOf(await api3Pool.agentAppSecondary())
           );
         }
-        expect(TreasuryAndUserDelegationData.names[erc20Tokens.length]).to.equal(
-          "Ethereum"
-        );
-        expect(TreasuryAndUserDelegationData.symbols[erc20Tokens.length]).to.equal(
-          "ETH"
-        );
-        expect(TreasuryAndUserDelegationData.decimals[erc20Tokens.length]).to.equal(
-          18
-        );
         expect(
-          TreasuryAndUserDelegationData.balancesOfPrimaryAgent[erc20Tokens.length]
-        ).to.equal(
-          ethers.utils.parseEther("12")
-        );
+          TreasuryAndUserDelegationData.names[erc20Tokens.length]
+        ).to.equal("Ethereum");
         expect(
-          TreasuryAndUserDelegationData.balancesOfSecondaryAgent[erc20Tokens.length]
-        ).to.equal(
-          ethers.utils.parseEther("34")
-        );
+          TreasuryAndUserDelegationData.symbols[erc20Tokens.length]
+        ).to.equal("ETH");
+        expect(
+          TreasuryAndUserDelegationData.decimals[erc20Tokens.length]
+        ).to.equal(18);
+        expect(
+          TreasuryAndUserDelegationData.balancesOfPrimaryAgent[
+            erc20Tokens.length
+          ]
+        ).to.equal(ethers.utils.parseEther("12"));
+        expect(
+          TreasuryAndUserDelegationData.balancesOfSecondaryAgent[
+            erc20Tokens.length
+          ]
+        ).to.equal(ethers.utils.parseEther("34"));
 
         expect(
           TreasuryAndUserDelegationData.proposalVotingPowerThreshold

--- a/packages/dao/scripts/deploy.js
+++ b/packages/dao/scripts/deploy.js
@@ -90,6 +90,8 @@ module.exports = async (callback) => {
       [supportRequiredPct2, minAcceptQuorumPct2],
       api3VotingAppId
     );
+    const dao = getEventArgument(tx, "Api3DaoDeployed", "dao");
+    const acl = getEventArgument(tx, "Api3DaoDeployed", "acl");
     const primaryVoting = getEventArgument(
       tx,
       "Api3DaoDeployed",
@@ -126,6 +128,8 @@ module.exports = async (callback) => {
       timelockManager: timelockManager.address,
       api3Pool: api3Pool.address,
       convenience: convenience.address,
+      dao: dao,
+      acl: acl,
       votingAppPrimary: getEventArgument(
         set_tx,
         "SetDaoApps",

--- a/packages/pool/contracts/ClaimUtils.sol
+++ b/packages/pool/contracts/ClaimUtils.sol
@@ -44,7 +44,8 @@ abstract contract ClaimUtils is StakeUtils, IClaimUtils {
         assert(api3Token.transfer(recipient, amount));
         emit PaidOutClaim(
             recipient,
-            amount
+            amount,
+            totalStake
             );
     }
 }

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -129,7 +129,7 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             users[delegate].delegatedTo,
             newDelegatedTo
             );
-        emit Delegated(
+        emit UpdatedDelegation(
             msg.sender,
             delegate,
             newDelegatedTo

--- a/packages/pool/contracts/DelegationUtils.sol
+++ b/packages/pool/contracts/DelegationUtils.sol
@@ -53,9 +53,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         }
 
         // Assign the new delegation
+        uint256 delegatedToUpdate = delegatedToUser(delegate) + userShares;
         updateCheckpointArray(
             users[delegate].delegatedTo,
-            delegatedToUser(delegate) + userShares
+            delegatedToUpdate
             );
 
         // Record the new delegate for the user
@@ -66,7 +67,8 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         emit Delegated(
             msg.sender,
             delegate,
-            userShares
+            userShares,
+            delegatedToUpdate
             );
     }
 
@@ -89,9 +91,10 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         user.lastDelegationUpdateTimestamp = block.timestamp;
 
         uint256 userShares = userShares(msg.sender);
+        uint256 delegatedToUpdate = delegatedToUser(previousDelegate) - userShares;
         updateCheckpointArray(
             users[previousDelegate].delegatedTo,
-            delegatedToUser(previousDelegate) - userShares
+            delegatedToUpdate
             );
         updateAddressCheckpointArray(
             user.delegates,
@@ -100,7 +103,8 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
         emit Undelegated(
             msg.sender,
             previousDelegate,
-            userShares
+            userShares,
+            delegatedToUpdate
             );
     }
 
@@ -122,17 +126,19 @@ abstract contract DelegationUtils is RewardUtils, IDelegationUtils {
             return;
         }
         uint256 currentDelegatedTo = delegatedToUser(delegate);
-        uint256 newDelegatedTo = delta
+        uint256 delegatedToUpdate = delta
             ? currentDelegatedTo + shares
             : currentDelegatedTo - shares;
         updateCheckpointArray(
             users[delegate].delegatedTo,
-            newDelegatedTo
+            delegatedToUpdate
             );
         emit UpdatedDelegation(
             msg.sender,
             delegate,
-            newDelegatedTo
+            delta,
+            shares,
+            delegatedToUpdate
             );
     }
 }

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -22,6 +22,8 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
             if (api3Token.getMinterStatus(address(this)))
             {
                 uint256 rewardAmount = totalStake * apr * EPOCH_LENGTH / 365 days / HUNDRED_PERCENT;
+                assert(block.number <= MAX_UINT32);
+                assert(rewardAmount <= MAX_UINT224);
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: uint32(block.number),
                     amount: uint224(rewardAmount),

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -36,7 +36,8 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
                 emit MintedReward(
                     currentEpoch,
                     rewardAmount,
-                    apr
+                    apr,
+                    totalStake
                     );
             }
             epochIndexOfLastReward = currentEpoch;

--- a/packages/pool/contracts/RewardUtils.sol
+++ b/packages/pool/contracts/RewardUtils.sol
@@ -27,7 +27,8 @@ abstract contract RewardUtils is GetterUtils, IRewardUtils {
                 epochIndexToReward[currentEpoch] = Reward({
                     atBlock: uint32(block.number),
                     amount: uint224(rewardAmount),
-                    totalSharesThen: totalShares()
+                    totalSharesThen: totalShares(),
+                    totalStakeThen: totalStake
                     });
                 api3Token.mint(address(this), rewardAmount);
                 totalStake += rewardAmount;

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -105,9 +105,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
     }
 
     /// @notice Called to execute a pre-scheduled unstake
-    /// @dev Note that anyone can execute a matured unstake. This is to allow
-    /// the user to use bots, etc. to execute their unstaking as soon as
-    /// possible.
+    /// @dev Anyone can execute a matured unstake. This is to allow the user to
+    /// use bots, etc. to execute their unstaking as soon as possible.
     /// @param userAddress User address
     /// @return Amount of tokens that are unstaked
     function unstake(address userAddress)
@@ -128,8 +127,9 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         uint256 totalShares = totalShares();
         uint256 unstakeAmount = user.unstakeAmount;
         uint256 unstakeAmountByShares = user.unstakeShares * totalStake / totalShares;
-        // If there was a claim payout in between the scheduling and the actual unstake 
-        // then the amount might be lower than expected at scheduling time
+        // If there was a claim payout in between the scheduling and the actual
+        // unstake then the amount might be lower than expected at scheduling
+        // time
         if (unstakeAmount > unstakeAmountByShares)
         {
             unstakeAmount = unstakeAmountByShares;
@@ -151,8 +151,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
 
     /// @notice Convenience method to execute an unstake and withdraw to the
     /// user's wallet in a single transaction
-    /// @dev Note that the withdrawal may revert because the user may have less
-    /// than `unstaked` tokens that are withdrawable
+    /// @dev The withdrawal will revert if the user has less than
+    /// `unstakeAmount` tokens that are withdrawable
     function unstakeAndWithdraw()
         external
         override

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -20,6 +20,7 @@ contract StateUtils is IStateUtils {
         uint32 atBlock;
         uint224 amount;
         uint256 totalSharesThen;
+        uint256 totalStakeThen;
     }
 
     struct User {

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -53,8 +53,8 @@ contract StateUtils is IStateUtils {
     uint256 public constant EPOCH_LENGTH = 1 weeks;
 
     /// @notice Number of epochs before the staking rewards get unlocked.
-    /// Hardcoded as 52 epochs, which corresponds to a year with an
-    /// `EPOCH_LENGTH` of 1 week.
+    /// Hardcoded as 52 epochs, which approximately corresponds to a year with
+    /// an `EPOCH_LENGTH` of 1 week.
     uint256 public constant REWARD_VESTING_PERIOD = 52;
 
     // All percentage values are represented as 1e18 = 100%

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -119,7 +119,7 @@ contract StateUtils is IStateUtils {
     /// amount is below this, and vice versa.
     /// @dev Default value is 50% of the total API3 token supply. This
     /// parameter is governable by the DAO.
-    uint256 public stakeTarget = 50 * ONE_PERCENT;
+    uint256 public stakeTarget = ONE_PERCENT * 50;
 
     /// @notice Minimum APR (annual percentage rate) the pool will pay as
     /// staking rewards in percentages
@@ -129,7 +129,7 @@ contract StateUtils is IStateUtils {
     /// @notice Maximum APR (annual percentage rate) the pool will pay as
     /// staking rewards in percentages
     /// @dev Default value is 75%. This parameter is governable by the DAO.
-    uint256 public maxApr = 75 * ONE_PERCENT;
+    uint256 public maxApr = ONE_PERCENT * 75;
 
     /// @notice Steps in which APR will be updated in percentages
     /// @dev Default value is 1%. This parameter is governable by the DAO.
@@ -389,7 +389,7 @@ contract StateUtils is IStateUtils {
     {
         require(
             _proposalVotingPowerThreshold >= ONE_PERCENT / 10
-                && _proposalVotingPowerThreshold <= 10 * ONE_PERCENT,
+                && _proposalVotingPowerThreshold <= ONE_PERCENT * 10,
             "Pool: Threshold outside limits");
         proposalVotingPowerThreshold = _proposalVotingPowerThreshold;
         emit SetProposalVotingPowerThreshold(_proposalVotingPowerThreshold);

--- a/packages/pool/contracts/StateUtils.sol
+++ b/packages/pool/contracts/StateUtils.sol
@@ -60,8 +60,9 @@ contract StateUtils is IStateUtils {
     uint256 internal constant ONE_PERCENT = 1e18 / 100;
     uint256 internal constant HUNDRED_PERCENT = 1e18;
 
-    uint256 private constant MAX_UINT32 = 2**32 - 1;
-    uint256 private constant MAX_UINT224 = 2**224 - 1;
+    // To assert that typecasts do not overflow
+    uint256 internal constant MAX_UINT32 = 2**32 - 1;
+    uint256 internal constant MAX_UINT224 = 2**224 - 1;
 
     /// @notice Epochs are indexed as `block.timestamp / EPOCH_LENGTH`.
     /// `genesisEpoch` is the index of the epoch in which the pool is deployed.

--- a/packages/pool/contracts/TimelockUtils.sol
+++ b/packages/pool/contracts/TimelockUtils.sol
@@ -6,7 +6,7 @@ import "./interfaces/ITimelockUtils.sol";
 
 /// @title Contract that implements vesting functionality
 /// @dev The TimelockManager contract interfaces with this contract to transfer
-/// API3 tokens that are locked under a vesting schedule
+/// API3 tokens that are locked under a vesting schedule.
 /// This contract keeps its own type definitions, event declarations and state
 /// variables for them to be easier to remove for a subDAO where they will
 /// likely not be used.
@@ -28,7 +28,7 @@ abstract contract TimelockUtils is ClaimUtils, ITimelockUtils {
     /// @notice Called by the TimelockManager contract to deposit tokens on
     /// behalf of a user
     /// @dev This method is only usable by `TimelockManager.sol`.
-    /// It is named as `deposit()` and not `depositByTimelockManager()` for
+    /// It is named as `deposit()` and not `depositAsTimelockManager()` for
     /// example, because the TimelockManager is already deployed and expects
     /// the `deposit(address,uint256,address)` interface.
     /// @param source Token transfer source

--- a/packages/pool/contracts/TransferUtils.sol
+++ b/packages/pool/contracts/TransferUtils.sol
@@ -17,13 +17,15 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
         override
     {
         mintReward();
-        users[msg.sender].unstaked += amount;
+        uint256 unstakedUpdate = users[msg.sender].unstaked + amount;
+        users[msg.sender].unstaked = unstakedUpdate;
         // Should never return false because the API3 token uses the
         // OpenZeppelin implementation
         assert(api3Token.transferFrom(msg.sender, address(this), amount));
         emit Deposited(
             msg.sender,
-            amount
+            amount,
+            unstakedUpdate
             );
     }
 
@@ -148,13 +150,15 @@ abstract contract TransferUtils is DelegationUtils, ITransferUtils {
             "Pool: Not enough unstaked funds"
             );
         // Carry on with the withdrawal
-        user.unstaked -= amount;
+        uint256 unstakedUpdate = user.unstaked - amount;
+        user.unstaked = unstakedUpdate;
         // Should never return false because the API3 token uses the
         // OpenZeppelin implementation
         assert(api3Token.transfer(msg.sender, amount));
         emit Withdrawn(
             msg.sender,
-            amount
+            amount,
+            unstakedUpdate
             );
     }
 }

--- a/packages/pool/contracts/interfaces/IClaimUtils.sol
+++ b/packages/pool/contracts/interfaces/IClaimUtils.sol
@@ -6,7 +6,8 @@ import "./IStakeUtils.sol";
 interface IClaimUtils is IStakeUtils {
     event PaidOutClaim(
         address indexed recipient,
-        uint256 amount
+        uint256 amount,
+        uint256 totalStake
         );
 
     function payOutClaim(

--- a/packages/pool/contracts/interfaces/IDelegationUtils.sol
+++ b/packages/pool/contracts/interfaces/IDelegationUtils.sol
@@ -16,6 +16,12 @@ interface IDelegationUtils is IRewardUtils {
         uint256 shares
         );
 
+    event UpdatedDelegation(
+        address indexed user,
+        address indexed delegate,
+        uint256 shares
+        );
+
     function delegateVotingPower(address delegate) 
         external;
 

--- a/packages/pool/contracts/interfaces/IDelegationUtils.sol
+++ b/packages/pool/contracts/interfaces/IDelegationUtils.sol
@@ -7,19 +7,23 @@ interface IDelegationUtils is IRewardUtils {
     event Delegated(
         address indexed user,
         address indexed delegate,
-        uint256 shares
+        uint256 shares,
+        uint256 totalDelegatedTo
         );
 
     event Undelegated(
         address indexed user,
         address indexed delegate,
-        uint256 shares
+        uint256 shares,
+        uint256 totalDelegatedTo
         );
 
     event UpdatedDelegation(
         address indexed user,
         address indexed delegate,
-        uint256 shares
+        bool delta,
+        uint256 shares,
+        uint256 totalDelegatedTo
         );
 
     function delegateVotingPower(address delegate) 

--- a/packages/pool/contracts/interfaces/IRewardUtils.sol
+++ b/packages/pool/contracts/interfaces/IRewardUtils.sol
@@ -7,7 +7,8 @@ interface IRewardUtils is IGetterUtils {
     event MintedReward(
         uint256 indexed epochIndex,
         uint256 amount,
-        uint256 newApr
+        uint256 newApr,
+        uint256 totalStake
         );
 
     function mintReward()

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -7,19 +7,23 @@ interface IStakeUtils is ITransferUtils{
     event Staked(
         address indexed user,
         uint256 amount,
-        uint256 shares
+        uint256 mintedShares,
+        uint256 userShares,
+        uint256 totalShares
         );
 
     event ScheduledUnstake(
         address indexed user,
         uint256 amount,
         uint256 shares,
-        uint256 scheduledFor
+        uint256 scheduledFor,
+        uint256 userShares
         );
 
     event Unstaked(
         address indexed user,
-        uint256 amount
+        uint256 amount,
+        uint256 totalShares
         );
 
     function stake(uint256 amount)

--- a/packages/pool/contracts/interfaces/ITimelockUtils.sol
+++ b/packages/pool/contracts/interfaces/ITimelockUtils.sol
@@ -6,19 +6,23 @@ import "./IClaimUtils.sol";
 interface ITimelockUtils is IClaimUtils {
     event DepositedByTimelockManager(
         address indexed user,
-        uint256 amount
+        uint256 amount,
+        uint256 userUnstaked
         );
 
     event DepositedVesting(
         address indexed user,
         uint256 amount,
         uint256 start,
-        uint256 end
+        uint256 end,
+        uint256 userUnstaked,
+        uint256 userVesting
         );
 
     event VestedTimelock(
         address indexed user,
-        uint256 amount
+        uint256 amount,
+        uint256 userVesting
         );
 
     function deposit(

--- a/packages/pool/contracts/interfaces/ITransferUtils.sol
+++ b/packages/pool/contracts/interfaces/ITransferUtils.sol
@@ -6,12 +6,14 @@ import "./IDelegationUtils.sol";
 interface ITransferUtils is IDelegationUtils{
     event Deposited(
         address indexed user,
-        uint256 amount
+        uint256 amount,
+        uint256 userUnstaked
         );
 
     event Withdrawn(
         address indexed user,
-        uint256 amount
+        uint256 amount,
+        uint256 userUnstaked
         );
 
     event CalculatingUserLocked(

--- a/packages/pool/test/ClaimUtils.sol.js
+++ b/packages/pool/test/ClaimUtils.sol.js
@@ -69,7 +69,11 @@ describe("payOutClaim", function () {
             .payOutClaim(roles.claimsManager.address, claimAmount)
         )
           .to.emit(api3Pool, "PaidOutClaim")
-          .withArgs(roles.claimsManager.address, claimAmount);
+          .withArgs(
+            roles.claimsManager.address,
+            claimAmount,
+            user1Stake.sub(claimAmount).add(1)
+          );
         expect(await api3Pool.userStake(roles.user1.address)).to.equal(
           user1Stake.sub(claimAmount)
         );

--- a/packages/pool/test/DelegationUtils.sol.js
+++ b/packages/pool/test/DelegationUtils.sol.js
@@ -101,6 +101,7 @@ describe("delegateVotingPower", function () {
                     .withArgs(
                       roles.user1.address,
                       roles.user2.address,
+                      user1Shares,
                       user1Shares
                     );
                   expect(
@@ -265,7 +266,7 @@ describe("undelegateVotingPower", function () {
           const user1Shares = await api3Pool.userShares(roles.user1.address);
           await expect(api3Pool.connect(roles.user1).undelegateVotingPower())
             .to.emit(api3Pool, "Undelegated")
-            .withArgs(roles.user1.address, roles.user2.address, user1Shares);
+            .withArgs(roles.user1.address, roles.user2.address, user1Shares, 0);
           expect(await api3Pool.userVotingPower(roles.user1.address)).to.equal(
             user1Stake
           );

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -89,7 +89,7 @@ describe("mintReward", function () {
               .div(HUNDRED_PERCENT);
             await expect(api3Pool.connect(roles.randomPerson).mintReward())
               .to.emit(api3Pool, "MintedReward")
-              .withArgs(nextEpoch, rewardAmount, newApr);
+              .withArgs(nextEpoch, rewardAmount, newApr, totalStake.add(rewardAmount));
             expect(await api3Pool.totalStake()).to.equal(
               totalStake.add(rewardAmount)
             );
@@ -153,7 +153,7 @@ describe("mintReward", function () {
               .div(HUNDRED_PERCENT);
             await expect(api3Pool.connect(roles.randomPerson).mintReward())
               .to.emit(api3Pool, "MintedReward")
-              .withArgs(nextEpoch, rewardAmount, newApr);
+              .withArgs(nextEpoch, rewardAmount, newApr, totalStake.add(rewardAmount));
             expect(await api3Pool.totalStake()).to.equal(
               totalStake.add(rewardAmount)
             );
@@ -254,7 +254,7 @@ describe("mintReward", function () {
           .div(HUNDRED_PERCENT);
         await expect(api3Pool.connect(roles.randomPerson).mintReward())
           .to.emit(api3Pool, "MintedReward")
-          .withArgs(genesisEpochPlusFive, rewardAmount, newApr);
+          .withArgs(genesisEpochPlusFive, rewardAmount, newApr, totalStake.add(rewardAmount));
         expect(await api3Pool.totalStake()).to.equal(
           totalStake.add(rewardAmount)
         );

--- a/packages/pool/test/RewardUtils.sol.js
+++ b/packages/pool/test/RewardUtils.sol.js
@@ -89,7 +89,12 @@ describe("mintReward", function () {
               .div(HUNDRED_PERCENT);
             await expect(api3Pool.connect(roles.randomPerson).mintReward())
               .to.emit(api3Pool, "MintedReward")
-              .withArgs(nextEpoch, rewardAmount, newApr, totalStake.add(rewardAmount));
+              .withArgs(
+                nextEpoch,
+                rewardAmount,
+                newApr,
+                totalStake.add(rewardAmount)
+              );
             expect(await api3Pool.totalStake()).to.equal(
               totalStake.add(rewardAmount)
             );
@@ -153,7 +158,12 @@ describe("mintReward", function () {
               .div(HUNDRED_PERCENT);
             await expect(api3Pool.connect(roles.randomPerson).mintReward())
               .to.emit(api3Pool, "MintedReward")
-              .withArgs(nextEpoch, rewardAmount, newApr, totalStake.add(rewardAmount));
+              .withArgs(
+                nextEpoch,
+                rewardAmount,
+                newApr,
+                totalStake.add(rewardAmount)
+              );
             expect(await api3Pool.totalStake()).to.equal(
               totalStake.add(rewardAmount)
             );
@@ -254,7 +264,12 @@ describe("mintReward", function () {
           .div(HUNDRED_PERCENT);
         await expect(api3Pool.connect(roles.randomPerson).mintReward())
           .to.emit(api3Pool, "MintedReward")
-          .withArgs(genesisEpochPlusFive, rewardAmount, newApr, totalStake.add(rewardAmount));
+          .withArgs(
+            genesisEpochPlusFive,
+            rewardAmount,
+            newApr,
+            totalStake.add(rewardAmount)
+          );
         expect(await api3Pool.totalStake()).to.equal(
           totalStake.add(rewardAmount)
         );

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -72,7 +72,13 @@ describe("stake", function () {
         // Stake the second half
         await expect(api3Pool.connect(roles.user1).stake(user1Stake.div(2)))
           .to.emit(api3Pool, "Staked")
-          .withArgs(roles.user1.address, user1Stake.div(2), user1Stake.div(2));
+          .withArgs(
+            roles.user1.address,
+            user1Stake.div(2),
+            user1Stake.div(2),
+            user1Stake,
+            user1Stake.add(1)
+          );
         expect(await api3Pool.userStake(roles.user1.address)).to.equal(
           user1Stake
         );
@@ -101,7 +107,13 @@ describe("stake", function () {
         await api3Pool.connect(roles.user1).depositRegular(user1Stake);
         await expect(api3Pool.connect(roles.user1).stake(user1Stake))
           .to.emit(api3Pool, "Staked")
-          .withArgs(roles.user1.address, user1Stake, user1Stake);
+          .withArgs(
+            roles.user1.address,
+            user1Stake,
+            user1Stake,
+            user1Stake,
+            user1Stake.add(1)
+          );
         expect(await api3Pool.userStake(roles.user1.address)).to.equal(
           user1Stake
         );
@@ -131,7 +143,13 @@ describe("depositAndStake", function () {
     await api3Token.connect(roles.user1).approve(api3Pool.address, user1Stake);
     await expect(api3Pool.connect(roles.user1).depositAndStake(user1Stake))
       .to.emit(api3Pool, "Staked")
-      .withArgs(roles.user1.address, user1Stake, user1Stake);
+      .withArgs(
+        roles.user1.address,
+        user1Stake,
+        user1Stake,
+        user1Stake,
+        user1Stake.add(1)
+      );
   });
 });
 
@@ -178,7 +196,8 @@ describe("scheduleUnstake", function () {
                 roles.user1.address,
                 user1Stake,
                 user1Shares,
-                unstakeScheduledFor
+                unstakeScheduledFor,
+                0
               );
             expect(await api3Pool.userShares(roles.user1.address)).to.equal(0);
             expect(await api3Pool.totalShares()).to.equal(user1Shares.add(1));
@@ -219,7 +238,8 @@ describe("scheduleUnstake", function () {
                 roles.user1.address,
                 user1Stake,
                 user1Shares,
-                unstakeScheduledFor
+                unstakeScheduledFor,
+                0
               );
             expect(await api3Pool.userShares(roles.user1.address)).to.equal(0);
             expect(await api3Pool.totalShares()).to.equal(user1Shares.add(1));
@@ -318,7 +338,7 @@ describe("unstake", function () {
             api3Pool.connect(roles.randomPerson).unstake(roles.user1.address)
           )
             .to.emit(api3Pool, "Unstaked")
-            .withArgs(roles.user1.address, user1Stake);
+            .withArgs(roles.user1.address, user1Stake, 1);
           const user = await api3Pool.users(roles.user1.address);
           expect(user.unstaked).to.equal(user1Stake);
         });
@@ -379,7 +399,11 @@ describe("unstake", function () {
             api3Pool.connect(roles.randomPerson).unstake(roles.user1.address)
           )
             .to.emit(api3Pool, "Unstaked")
-            .withArgs(roles.user1.address, actualUnstakeAmount);
+            .withArgs(
+              roles.user1.address,
+              actualUnstakeAmount,
+              user1Stake.div(2).add(1)
+            );
         });
       });
     });

--- a/packages/pool/test/TimelockUtils.sol.js
+++ b/packages/pool/test/TimelockUtils.sol.js
@@ -58,7 +58,11 @@ describe("deposit", function () {
           )
       )
         .to.emit(api3Pool, "DepositedByTimelockManager")
-        .withArgs(roles.user1.address, timelockManagerDeposit);
+        .withArgs(
+          roles.user1.address,
+          timelockManagerDeposit,
+          timelockManagerDeposit
+        );
       const user = await api3Pool.users(roles.user1.address);
       expect(user.unstaked).to.equal(timelockManagerDeposit);
     });
@@ -115,7 +119,9 @@ describe("depositWithVesting", function () {
                 roles.user1.address,
                 depositAmount,
                 releaseStart,
-                releaseEnd
+                releaseEnd,
+                depositAmount,
+                depositAmount
               );
           });
         });
@@ -171,7 +177,9 @@ describe("depositWithVesting", function () {
               roles.user1.address,
               depositAmount,
               releaseEnd - 1,
-              releaseEnd
+              releaseEnd,
+              depositAmount,
+              depositAmount
             );
         });
       });
@@ -274,7 +282,7 @@ describe("updateTimelockStatus", function () {
               .updateTimelockStatus(roles.user1.address)
           )
             .to.emit(api3Pool, "VestedTimelock")
-            .withArgs(roles.user1.address, depositAmount);
+            .withArgs(roles.user1.address, depositAmount, 0);
         });
       });
       context("It is not past release end", function () {
@@ -307,7 +315,11 @@ describe("updateTimelockStatus", function () {
               .updateTimelockStatus(roles.user1.address)
           )
             .to.emit(api3Pool, "VestedTimelock")
-            .withArgs(roles.user1.address, depositAmount.div(2));
+            .withArgs(
+              roles.user1.address,
+              depositAmount.div(2),
+              depositAmount.div(2)
+            );
         });
       });
     });

--- a/packages/pool/test/TransferUtils.sol.js
+++ b/packages/pool/test/TransferUtils.sol.js
@@ -49,7 +49,7 @@ describe("depositRegular", function () {
       .approve(api3Pool.address, user1Deposit);
     await expect(api3Pool.connect(roles.user1).depositRegular(user1Deposit))
       .to.emit(api3Pool, "Deposited")
-      .withArgs(roles.user1.address, user1Deposit);
+      .withArgs(roles.user1.address, user1Deposit, user1Deposit);
     const user = await api3Pool.users(roles.user1.address);
     expect(user.unstaked).to.equal(user1Deposit);
   });
@@ -94,7 +94,11 @@ describe("withdrawRegular", function () {
       const unlocked = userBefore.unstaked.sub(locked);
       await expect(api3Pool.connect(roles.user1).withdrawRegular(unlocked))
         .to.emit(api3Pool, "Withdrawn")
-        .withArgs(roles.user1.address, unlocked);
+        .withArgs(
+          roles.user1.address,
+          unlocked,
+          userBefore.unstaked.sub(unlocked)
+        );
       const userAfter = await api3Pool.users(roles.user1.address);
       expect(locked).to.equal(userAfter.unstaked);
     });
@@ -238,11 +242,16 @@ describe("withdrawPrecalculated", function () {
         await api3Pool
           .connect(roles.user1)
           .precalculateUserLocked(roles.user1.address, 30);
+        const userBefore = await api3Pool.users(roles.user1.address);
         await expect(
           api3Pool.connect(roles.user1).withdrawPrecalculated(user1Stake)
         )
           .to.emit(api3Pool, "Withdrawn")
-          .withArgs(roles.user1.address, user1Stake);
+          .withArgs(
+            roles.user1.address,
+            user1Stake,
+            userBefore.unstaked.sub(user1Stake)
+          );
       });
     });
     context("Calculation is not complete", function () {


### PR DESCRIPTION
A bunch of small fixes:

- In Api3Voting, `EPOCH_LENGTH` is already assigned to `voteTime` in `initialize()` and since `EPOCH_LENGTH` and `voteTime` don't change, we can use `voteTime` instead of fetching `EPOCH_LENGTH` from the pool contract. It will just be slightly cheaper.

- Typecasts at checkpoint arrays were `assert()`ed but the ones at reward records weren't, so added it for the sake of completeness.

- `totalStake` is added to the reward records. This is actually not used in anywhere in the contract, but the problem I wanted to solve is that we don't keep any history of total staked amount on-chain for someone to build an external contract that uses that somehow. It just makes reward payments a bit more expensive so felt like it's worth it.

- Delegation and delegation update events being the same was confusing, so created another one.

- Small formatting and comment stuff