### PR TITLE
Remove the workaround for the (non-existent) TimelockManager bug

### DIFF
--- a/packages/pool/contracts/TimelockUtils.sol
+++ b/packages/pool/contracts/TimelockUtils.sol
@@ -60,10 +60,7 @@ abstract contract TimelockUtils is ClaimUtils, ITimelockUtils {
 
     /// @notice Called by the TimelockManager contract to deposit tokens on
     /// behalf of a user on a linear vesting schedule
-    /// @dev Refer to `TimelockManager.sol` to see how this is used.
-    /// Note that `releaseStart` gets updated as `releaseEnd - 1` if it is
-    /// equal to or greater than `releaseEnd`. This is to accomodate for the
-    /// already deployed TimelockManager. See the code below for more context. 
+    /// @dev Refer to `TimelockManager.sol` to see how this is used
     /// @param source Token source
     /// @param amount Token amount
     /// @param userAddress Address of the user who will receive the tokens
@@ -87,20 +84,10 @@ abstract contract TimelockUtils is ClaimUtils, ITimelockUtils {
             userToTimelock[userAddress].remainingAmount == 0,
             "Pool: User has active timelock"
             );
-        /*
         require(
             releaseEnd > releaseStart,
             "Pool: Timelock start after end"
             );
-        // While calling `depositWithVesting()`, if the time is later than
-        // `releaseEnd`, TimelockManager may call this contract with
-        // `releaseStart` that is larger than `releaseEnd`. Instead of
-        // reverting, simply update `releaseStart`.
-        */
-        if (releaseStart >= releaseEnd)
-        {
-            releaseStart = releaseEnd - 1;
-        }
         require(
             amount != 0,
             "Pool: Timelock amount zero"

--- a/packages/pool/test/TimelockUtils.sol.js
+++ b/packages/pool/test/TimelockUtils.sol.js
@@ -148,7 +148,7 @@ describe("depositWithVesting", function () {
         });
       });
       context("Release end is not later than release start", function () {
-        it("updates release start and deposits with vesting", async function () {
+        it("reverts", async function () {
           const depositAmount = ethers.utils.parseEther("20" + "000" + "000");
           await api3Token
             .connect(roles.deployer)
@@ -171,16 +171,7 @@ describe("depositWithVesting", function () {
                 releaseStart,
                 releaseEnd
               )
-          )
-            .to.emit(api3Pool, "DepositedVesting")
-            .withArgs(
-              roles.user1.address,
-              depositAmount,
-              releaseEnd - 1,
-              releaseEnd,
-              depositAmount,
-              depositAmount
-            );
+          ).to.be.revertedWith("Pool: Timelock start after end");
         });
       });
     });


### PR DESCRIPTION
The current implementation has a [workaround](https://github.com/api3dao/api3-dao/blob/main/packages/pool/contracts/TimelockUtils.sol#L100-L103) that ensures that `releaseStart<releaseEnd`, based on the concern that if we are past `releaseEnd` when `withdrawToPool()` is called, [this line](https://github.com/api3dao/api3-dao/blob/e05d4a383f07dac594791952075f87c196a95044/packages/pool/contracts/auxiliary/TimelockManager.sol#L283) will cause the transferred timelock to have a larger `releaseStart` than `releaseEnd`.

This concern is invalid, as [if `now>=releaseEnd`](https://github.com/api3dao/api3-dao/blob/e05d4a383f07dac594791952075f87c196a95044/packages/pool/contracts/auxiliary/TimelockManager.sol#L325), the entire timelock will be unlocked, resulting in `timelocked` being 0 and the offending line not being reached. In other words, `TimelockManager.sol` has no issue that needs to be worked around, so the related "fix" can be reverted. This shouldn't affect how things work in practice.