### PR TITLE
Add totalStake to Staked and Unstaked events

### DIFF
--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -18,7 +18,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
             user.unstaked >= amount,
             "Pool: Amount exceeds unstaked"
             );
-        user.unstaked -= amount;
+        uint256 userUnstakedUpdate = user.unstaked - amount;
+        user.unstaked = userUnstakedUpdate;
         uint256 totalSharesNow = totalShares();
         uint256 sharesToMint = amount * totalSharesNow / totalStake;
         uint256 userSharesUpdate = userShares(msg.sender) + sharesToMint;
@@ -37,6 +38,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
             msg.sender,
             amount,
             sharesToMint,
+            userUnstakedUpdate,
             userSharesUpdate,
             totalSharesUpdate,
             totalStake
@@ -140,7 +142,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         {
             unstakeAmount = unstakeAmountByShares;
         }
-        user.unstaked += unstakeAmount;
+        uint256 userUnstakedUpdate = user.unstaked + unstakeAmount;
+        user.unstaked = userUnstakedUpdate;
 
         uint256 totalSharesUpdate = totalShares - user.unstakeShares;
         updateCheckpointArray(
@@ -155,6 +158,7 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         emit Unstaked(
             userAddress,
             unstakeAmount,
+            userUnstakedUpdate,
             totalSharesUpdate,
             totalStake
             );

--- a/packages/pool/contracts/StakeUtils.sol
+++ b/packages/pool/contracts/StakeUtils.sol
@@ -38,7 +38,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
             amount,
             sharesToMint,
             userSharesUpdate,
-            totalSharesUpdate
+            totalSharesUpdate,
+            totalStake
             );
     }
 
@@ -154,7 +155,8 @@ abstract contract StakeUtils is TransferUtils, IStakeUtils {
         emit Unstaked(
             userAddress,
             unstakeAmount,
-            totalSharesUpdate
+            totalSharesUpdate,
+            totalStake
             );
         return unstakeAmount;
     }

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -9,7 +9,8 @@ interface IStakeUtils is ITransferUtils{
         uint256 amount,
         uint256 mintedShares,
         uint256 userShares,
-        uint256 totalShares
+        uint256 totalShares,
+        uint256 totalStake
         );
 
     event ScheduledUnstake(
@@ -23,7 +24,8 @@ interface IStakeUtils is ITransferUtils{
     event Unstaked(
         address indexed user,
         uint256 amount,
-        uint256 totalShares
+        uint256 totalShares,
+        uint256 totalStake
         );
 
     function stake(uint256 amount)

--- a/packages/pool/contracts/interfaces/IStakeUtils.sol
+++ b/packages/pool/contracts/interfaces/IStakeUtils.sol
@@ -8,6 +8,7 @@ interface IStakeUtils is ITransferUtils{
         address indexed user,
         uint256 amount,
         uint256 mintedShares,
+        uint256 userUnstaked,
         uint256 userShares,
         uint256 totalShares,
         uint256 totalStake
@@ -24,6 +25,7 @@ interface IStakeUtils is ITransferUtils{
     event Unstaked(
         address indexed user,
         uint256 amount,
+        uint256 userUnstaked,
         uint256 totalShares,
         uint256 totalStake
         );

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -77,6 +77,7 @@ describe("stake", function () {
             user1Stake.div(2),
             user1Stake.div(2),
             user1Stake,
+            user1Stake.add(1),
             user1Stake.add(1)
           );
         expect(await api3Pool.userStake(roles.user1.address)).to.equal(
@@ -112,6 +113,7 @@ describe("stake", function () {
             user1Stake,
             user1Stake,
             user1Stake,
+            user1Stake.add(1),
             user1Stake.add(1)
           );
         expect(await api3Pool.userStake(roles.user1.address)).to.equal(
@@ -148,6 +150,7 @@ describe("depositAndStake", function () {
         user1Stake,
         user1Stake,
         user1Stake,
+        user1Stake.add(1),
         user1Stake.add(1)
       );
   });
@@ -334,11 +337,17 @@ describe("unstake", function () {
           ]);
           // Unstake
           await api3Pool.mintReward();
+          const totalStake = await api3Pool.totalStake();
           await expect(
             api3Pool.connect(roles.randomPerson).unstake(roles.user1.address)
           )
             .to.emit(api3Pool, "Unstaked")
-            .withArgs(roles.user1.address, user1Stake, 1);
+            .withArgs(
+              roles.user1.address,
+              user1Stake,
+              1,
+              totalStake.sub(user1Stake)
+            );
           const user = await api3Pool.users(roles.user1.address);
           expect(user.unstaked).to.equal(user1Stake);
         });
@@ -395,6 +404,7 @@ describe("unstake", function () {
           const actualUnstakeAmount = unstakeShares
             .mul(await api3Pool.totalStake())
             .div(await api3Pool.totalShares());
+          const totalStake = await api3Pool.totalStake();
           await expect(
             api3Pool.connect(roles.randomPerson).unstake(roles.user1.address)
           )
@@ -402,7 +412,8 @@ describe("unstake", function () {
             .withArgs(
               roles.user1.address,
               actualUnstakeAmount,
-              user1Stake.div(2).add(1)
+              user1Stake.div(2).add(1),
+              totalStake.sub(actualUnstakeAmount)
             );
         });
       });

--- a/packages/pool/test/StakeUtils.sol.js
+++ b/packages/pool/test/StakeUtils.sol.js
@@ -76,6 +76,7 @@ describe("stake", function () {
             roles.user1.address,
             user1Stake.div(2),
             user1Stake.div(2),
+            0,
             user1Stake,
             user1Stake.add(1),
             user1Stake.add(1)
@@ -112,6 +113,7 @@ describe("stake", function () {
             roles.user1.address,
             user1Stake,
             user1Stake,
+            0,
             user1Stake,
             user1Stake.add(1),
             user1Stake.add(1)
@@ -149,6 +151,7 @@ describe("depositAndStake", function () {
         roles.user1.address,
         user1Stake,
         user1Stake,
+        0,
         user1Stake,
         user1Stake.add(1),
         user1Stake.add(1)
@@ -345,6 +348,7 @@ describe("unstake", function () {
             .withArgs(
               roles.user1.address,
               user1Stake,
+              user1Stake,
               1,
               totalStake.sub(user1Stake)
             );
@@ -411,6 +415,7 @@ describe("unstake", function () {
             .to.emit(api3Pool, "Unstaked")
             .withArgs(
               roles.user1.address,
+              actualUnstakeAmount,
               actualUnstakeAmount,
               user1Stake.div(2).add(1),
               totalStake.sub(actualUnstakeAmount)


### PR DESCRIPTION
Title says all, just a small addition. `stake()` and `unstake()` update `totalStake`, so we want to emit it in the event for consistency.